### PR TITLE
PR4 (superseded): Refactor Range Queries (4 files) + tests

### DIFF
--- a/Range Queries/Lazy_SGT.cpp
+++ b/Range Queries/Lazy_SGT.cpp
@@ -11,7 +11,9 @@ struct LazySGT {
     vector<Update> updates;
     int n, s;
 
-    LazySGT(int n, vector<long long>& a) : n(n), s(1) {
+    LazySGT(int n, vector<long long>& a) {
+        this->n = n;
+        s = 1;
         while (s < 2 * n) s <<= 1;
         tree.resize(s, Node());
         lazy.resize(s, false);
@@ -64,8 +66,14 @@ struct LazySGT {
         return ans;
     }
 
-    void make_update(int l, int r, long long val) { Update u(val); _update(0, n - 1, 1, l, r, u); }
-    Node make_query(int l, int r) { return _query(0, n - 1, 1, l, r); }
+    void make_update(int l, int r, long long val) {
+        Update u(val);
+        _update(0, n - 1, 1, l, r, u);
+    }
+
+    Node make_query(int l, int r) {
+        return _query(0, n - 1, 1, l, r);
+    }
 };
 
 // Example: range-assign update, range-sum query

--- a/Range Queries/Lazy_SGT.cpp
+++ b/Range Queries/Lazy_SGT.cpp
@@ -1,116 +1,84 @@
-// Credits to HealthyUG for the inspiration.
-// Lazy Segment Tree with Range Updates and Range Queries
-// Supports multiple Segment Trees with just a change in the Node and Update
-// Very few changes required everytime
+// Lazy Segment Tree — O(N) build, O(log N) range update and range query
+// Customise Node1 (merge, identity) and Update1 (apply, combine, identity) for your problem.
+// Example below: range-assign with range-sum queries.
+#include <bits/stdc++.h>
+using namespace std;
 
 template<typename Node, typename Update>
 struct LazySGT {
     vector<Node> tree;
     vector<bool> lazy;
     vector<Update> updates;
-    vector<ll> arr; // type may change
-    int n;
-    int s;
-    LazySGT(int a_len, vector<ll> &a) { // change if type updated
-        arr = a;
-        n = a_len;
-        s = 1;
-        while(s < 2 * n){
-            s = s << 1;
-        }
-        tree.resize(s); fill(all(tree), Node());
-        lazy.resize(s); fill(all(lazy), false);
-        updates.resize(s); fill(all(updates), Update());
-        build(0, n - 1, 1);
+    int n, s;
+
+    LazySGT(int n, vector<long long>& a) : n(n), s(1) {
+        while (s < 2 * n) s <<= 1;
+        tree.resize(s, Node());
+        lazy.resize(s, false);
+        updates.resize(s, Update());
+        _build(a, 0, n - 1, 1);
     }
-    void build(int start, int end, int index) { // Never change this
-        if (start == end)   {
-            tree[index] = Node(arr[start]);
-            return;
-        }
-        int mid = (start + end) / 2;
-        build(start, mid, 2 * index);
-        build(mid + 1, end, 2 * index + 1);
-        tree[index].merge(tree[2 * index], tree[2 * index + 1]);
+
+    void _build(vector<long long>& a, int l, int r, int idx) {
+        if (l == r) { tree[idx] = Node(a[l]); return; }
+        int m = (l + r) / 2;
+        _build(a, l, m, 2 * idx);
+        _build(a, m + 1, r, 2 * idx + 1);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
     }
-    void pushdown(int index, int start, int end){
-        if(lazy[index]){
-            int mid = (start + end) / 2;
-            apply(2 * index, start, mid, updates[index]);
-            apply(2 * index + 1, mid + 1, end, updates[index]);
-            updates[index] = Update();
-            lazy[index] = 0;
+
+    void _apply(int idx, int l, int r, Update& u) {
+        if (l != r) { lazy[idx] = true; updates[idx].combine(u, l, r); }
+        u.apply(tree[idx], l, r);
+    }
+
+    void _pushdown(int idx, int l, int r) {
+        if (lazy[idx]) {
+            int m = (l + r) / 2;
+            _apply(2 * idx, l, m, updates[idx]);
+            _apply(2 * idx + 1, m + 1, r, updates[idx]);
+            updates[idx] = Update();
+            lazy[idx] = false;
         }
     }
-    void apply(int index, int start, int end, Update& u){
-        if(start != end){
-            lazy[index] = 1;
-            updates[index].combine(u, start, end);
-        }
-        u.apply(tree[index], start, end);
+
+    void _update(int l, int r, int idx, int ql, int qr, Update& u) {
+        if (l > qr || r < ql) return;
+        if (l >= ql && r <= qr) { _apply(idx, l, r, u); return; }
+        _pushdown(idx, l, r);
+        int m = (l + r) / 2;
+        _update(l, m, 2 * idx, ql, qr, u);
+        _update(m + 1, r, 2 * idx + 1, ql, qr, u);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
     }
-    void update(int start, int end, int index, int left, int right, Update& u) {  // Never Change this
-        if(start > right || end < left)
-            return;
-        if(start >= left && end <= right){
-            apply(index, start, end, u);
-            return;
-        }
-        pushdown(index, start, end);
-        int mid = (start + end) / 2;
-        update(start, mid, 2 * index, left, right, u);
-        update(mid + 1, end, 2 * index + 1, left, right, u);
-        tree[index].merge(tree[2 * index], tree[2 * index + 1]);
-    }
-    Node query(int start, int end, int index, int left, int right) { // Never change this
-        if (start > right || end < left)
-            return Node();
-        if (start >= left && end <= right){
-            pushdown(index, start, end);
-            return tree[index];
-        }
-        pushdown(index, start, end);
-        int mid = (start + end) / 2;
-        Node l, r, ans;
-        l = query(start, mid, 2 * index, left, right);
-        r = query(mid + 1, end, 2 * index + 1, left, right);
-        ans.merge(l, r);
+
+    Node _query(int l, int r, int idx, int ql, int qr) {
+        if (l > qr || r < ql) return Node();
+        if (l >= ql && r <= qr) { _pushdown(idx, l, r); return tree[idx]; }
+        _pushdown(idx, l, r);
+        int m = (l + r) / 2;
+        Node left = _query(l, m, 2 * idx, ql, qr);
+        Node right = _query(m + 1, r, 2 * idx + 1, ql, qr);
+        Node ans;
+        ans.merge(left, right);
         return ans;
     }
-    void make_update(int left, int right, ll val) {  // pass in as many parameters as required
-        Update new_update = Update(val); // may change
-        update(0, n - 1, 1, left, right, new_update);
-    }
-    Node make_query(int left, int right) {
-        return query(0, n - 1, 1, left, right);
-    }
+
+    void make_update(int l, int r, long long val) { Update u(val); _update(0, n - 1, 1, l, r, u); }
+    Node make_query(int l, int r) { return _query(0, n - 1, 1, l, r); }
 };
 
+// Example: range-assign update, range-sum query
 struct Node1 {
-    ll val; // may change
-    Node1() { // Identity element
-        val = 0;    // may change
-    }
-    Node1(ll p1) {  // Actual Node
-        val = p1; // may change
-    }
-    void merge(Node1 &l, Node1 &r) { // Merge two child nodes
-        val = l.val + r.val;  // may change
-    }
+    long long val = 0;
+    Node1() = default;
+    Node1(long long v) : val(v) {}
+    void merge(const Node1& l, const Node1& r) { val = l.val + r.val; }
 };
-
 struct Update1 {
-    ll val; // may change
-    Update1(){ // Identity update
-        val = 0;
-    }
-    Update1(ll val1) { // Actual Update
-        val = val1;
-    }
-    void apply(Node1 &a, int start, int end) { // apply update to given node
-        a.val = val * (end - start + 1); // may change
-    }
-    void combine(Update1& new_update, int start, int end){
-        val = new_update.val;
-    }
+    long long val = 0;
+    Update1() = default;
+    Update1(long long v) : val(v) {}
+    void apply(Node1& a, int l, int r) { a.val = val * (r - l + 1); }
+    void combine(const Update1& newer, int /*l*/, int /*r*/) { val = newer.val; }
 };

--- a/Range Queries/Mo_algo.cpp
+++ b/Range Queries/Mo_algo.cpp
@@ -1,141 +1,45 @@
-/* Priyansh Agarwal*/
-#include<bits/stdc++.h>
-#include<ext/pb_ds/assoc_container.hpp>
-#include<ext/pb_ds/tree_policy.hpp>
-#include<algorithm>
-#include<unordered_map>
-#include<vector>
-#include<unordered_set>
-#include<set>
-#include<map>
-#include<queue>
-#include<stack>
-#include<map>
-#include<chrono>
+// O((N+Q)√N) — Mo's Algorithm for offline range queries (distinct count example)
+// arr: input array (0-indexed); queries: list of {l, r} inclusive ranges
+// Returns answer[i] = number of distinct elements in arr[queries[i].l .. queries[i].r]
+#include <bits/stdc++.h>
 using namespace std;
-using namespace __gnu_pbds;
-using namespace chrono;
-#define fastio() ios_base::sync_with_stdio(false);cin.tie(NULL);cout.tie(NULL)
-#define MOD 1000000007
-#define MOD1 998244353
-#define nline "\n"
-#define pb push_back
-#define mp make_pair
-#define ff first
-#define ss second
-#define PI 3.141592653589793238462
-#define debug(x) cout << #x << " " << x <<endl;
-#define set_bits __builtin_popcount
-typedef long long ll;
-typedef unsigned long long ull;
-typedef long double lld;
-typedef tree<int, null_type, less<int>, rb_tree_tag, tree_order_statistics_node_update > pbds;
-/*---------------------------------------------------------------------------------------------------------------------------*/
-ll gcd(ll a, ll b) {if (b > a) {return gcd(b, a);} if (b == 0) {return a;} return gcd(b, a % b);}
-ll expo(ll a, ll b, ll mod) {ll res = 1; while (b > 0) {if (b & 1)res = (res * a) % mod; a = (a * a) % mod; b = b >> 1;} return res;}
-void extendgcd(ll a, ll b, ll*v) {if (b == 0) {v[0] = 1; v[1] = 0; v[2] = a; return ;} extendgcd(b, a % b, v); ll x = v[1]; v[1] = v[0] - v[1] * (a / b); v[0] = x; return;} //pass an arry of size 3
-ll mminv(ll a, ll b) {ll arr[3]; extendgcd(a, b, arr); return arr[0];} //for non prime b
-ll mminvprime(ll a, ll b) {return expo(a, b - 2, b);}
-bool revsort(ll a, ll b) {return a > b;}
-void swap(int &x, int &y) {int temp = x; x = y; y = temp;}
-ll combination(ll n, ll r, ll m, ll* fact) {ll val1 = fact[n]; ll val2 = mminvprime(fact[r], m); ll val3 = mminvprime(fact[n - r], m); return ((val1 * val2) % m * val3) % m;}
-void google(int t) {cout << "Case #" << t << ": ";}
-vector<int> sieve(int n) {int*arr = new int[n + 1](); vector<int> vect; for (int i = 2; i <= n; i++)if (arr[i] == 0) {vect.push_back(i); for (int j = 2 * i; j <= n; j += i)arr[j] = 1;} return vect;}
-/*--------------------------------------------------------------------------------------------------------------------------*/
-const int block_size = 450;
-bool compare(pair<pair<int, int>, int> p1, pair<pair<int, int>, int> p2)
-{
-	int b1 = p1.ff.ff / block_size;
-	int b2 = p2.ff.ff / block_size;
-	if (b1 == b2)
-		return b1 % 2 == 0 ? (p1.ff.ss < p2.ff.ss) : (p1.ff.ss > p2.ff.ss);
-	return b1 < b2;
-}
-int main()
-{
-	fastio();
-#ifndef ONLINE_JUDGE
-	freopen("Input.txt", "r", stdin);
-	freopen("Output.txt", "w", stdout);
-	freopen("Error.txt", "w", stderr);
-#endif
-	auto start1 = high_resolution_clock::now();
-	int n, q;
-	cin >> n >> q;
-	// block_size = int(sqrt(n + 0.0) + 1);
-	int *arr = new int[n];
-	int *freq = new int[n + 1]();
-	int number = 1;
-	map<int, int> coordinate_compression;
-	for (int i = 0; i < n; i++)
-	{
-		cin >> arr[i];
-		if (coordinate_compression.find(arr[i]) == coordinate_compression.end())
-		{
-			coordinate_compression[arr[i]] = number;
-			arr[i] = number;
-			number++;
-		}
-		else
-			arr[i] = coordinate_compression[arr[i]];
-	}
-	int start = 0;
-	int end = -1;
-	vector<pair<pair<int, int>, int>> ans(q);
-	for (int i = 0; i < q; i ++)
-	{
-		int a, b;
-		cin >> a >> b;
-		ans[i] = {{a, b}, i};
-	}
-	sort(ans.begin(), ans.end(), compare);
-	int *ans1 = new int[q];
-	int count = 0;
-	for (auto i : ans)
-	{
-		pair<pair<int, int>, int> p1 = i;
-		int right = p1.ff.ss - 1;
-		int left = p1.ff.ff - 1;
-		while (start < left)
-		{
-			int x = arr[start];
-			freq[x]--;
-			if (freq[x] == 0)
-				count--;
-			start++;
-		}
-		while (start > left)
-		{
-			start--;
-			int x = arr[start];
-			freq[x]++;
-			if (freq[x] == 1)
-				count++;
-		}
-		while (end < right)
-		{
-			end++;
-			int x = arr[end];
-			freq[x]++;
-			if (freq[x] == 1)
-				count++;
-		}
-		while (end > right)
-		{
-			int x = arr[end];
-			freq[x]--;
-			if (freq[x] == 0)
-				count--;
-			end--;
-		}
-		ans1[p1.ss] = count;
-	}
-	for (int i = 0; i < q; i++)
-		cout << ans1[i] << "\n";
-	auto stop1 = high_resolution_clock::now();
-	auto duration = duration_cast<microseconds>(stop1 - start1);
-#ifndef ONLINE_JUDGE
-	cerr << "Time: " << duration.count() / 1000.0 << endl;
-#endif
-	return 0;
+
+vector<int> moDistinctQueries(int n, vector<int> arr, vector<pair<int, int>>& queries) {
+    const int block = max(1, (int)sqrt(n));
+    int q = (int)queries.size();
+
+    // Coordinate compress arr
+    map<int, int> compress;
+    int id = 0;
+    for (int& x : arr) {
+        if (!compress.count(x)) compress[x] = id++;
+        x = compress[x];
+    }
+
+    // Tag queries with original index, then sort by Mo's order
+    vector<pair<pair<int, int>, int>> indexed(q);
+    for (int i = 0; i < q; i++) indexed[i] = {{queries[i].first, queries[i].second}, i};
+    sort(indexed.begin(), indexed.end(),
+        [&](auto& a, auto& b) {
+            int ba = a.first.first / block, bb = b.first.first / block;
+            if (ba != bb) return ba < bb;
+            return (ba & 1) ? a.first.second > b.first.second
+                            : a.first.second < b.first.second;
+        });
+
+    vector<int> freq(n, 0), ans(q);
+    int cur = 0, lo = 0, hi = -1;
+
+    auto add = [&](int pos) { if (++freq[arr[pos]] == 1) cur++; };
+    auto rem = [&](int pos) { if (--freq[arr[pos]] == 0) cur--; };
+
+    for (auto& [range, origIdx] : indexed) {
+        auto [l, r] = range;
+        while (hi < r) add(++hi);
+        while (lo > l) add(--lo);
+        while (hi > r) rem(hi--);
+        while (lo < l) rem(lo++);
+        ans[origIdx] = cur;
+    }
+    return ans;
 }

--- a/Range Queries/Mo_algo.cpp
+++ b/Range Queries/Mo_algo.cpp
@@ -19,19 +19,27 @@ vector<int> moDistinctQueries(int n, vector<int> arr, vector<pair<int, int>>& qu
     // Tag queries with original index, then sort by Mo's order
     vector<pair<pair<int, int>, int>> indexed(q);
     for (int i = 0; i < q; i++) indexed[i] = {{queries[i].first, queries[i].second}, i};
-    sort(indexed.begin(), indexed.end(),
-        [&](auto& a, auto& b) {
-            int ba = a.first.first / block, bb = b.first.first / block;
-            if (ba != bb) return ba < bb;
-            return (ba & 1) ? a.first.second > b.first.second
-                            : a.first.second < b.first.second;
-        });
+
+    // Sort: primary key = block of l; secondary key = r, alternating direction
+    // per block (odd blocks descending) to reduce total pointer movement
+    auto moCmp = [&](const auto& a, const auto& b) {
+        int ba = a.first.first / block;
+        int bb = b.first.first / block;
+        if (ba != bb) return ba < bb;
+        return (ba & 1) ? a.first.second > b.first.second
+                        : a.first.second < b.first.second;
+    };
+    sort(indexed.begin(), indexed.end(), moCmp);
 
     vector<int> freq(n, 0), ans(q);
     int cur = 0, lo = 0, hi = -1;
 
-    auto add = [&](int pos) { if (++freq[arr[pos]] == 1) cur++; };
-    auto rem = [&](int pos) { if (--freq[arr[pos]] == 0) cur--; };
+    auto add = [&](int pos) {
+        if (++freq[arr[pos]] == 1) cur++;
+    };
+    auto rem = [&](int pos) {
+        if (--freq[arr[pos]] == 0) cur--;
+    };
 
     for (auto& [range, origIdx] : indexed) {
         auto [l, r] = range;

--- a/Range Queries/Segment_tree.cpp
+++ b/Range Queries/Segment_tree.cpp
@@ -9,7 +9,9 @@ struct SegTree {
     vector<Node> tree;
     int n, s;
 
-    SegTree(int n, vector<long long>& a) : n(n), s(1) {
+    SegTree(int n, vector<long long>& a) {
+        this->n = n;
+        s = 1;
         while (s < 2 * n) s <<= 1;
         tree.resize(s, Node());
         _build(a, 0, n - 1, 1);
@@ -42,8 +44,14 @@ struct SegTree {
         return ans;
     }
 
-    void make_update(int pos, long long val) { Update u(val); _update(0, n - 1, 1, pos, u); }
-    Node make_query(int l, int r) { return _query(0, n - 1, 1, l, r); }
+    void make_update(int pos, long long val) {
+        Update u(val);
+        _update(0, n - 1, 1, pos, u);
+    }
+
+    Node make_query(int l, int r) {
+        return _query(0, n - 1, 1, l, r);
+    }
 };
 
 // Example: XOR aggregate, point-set update

--- a/Range Queries/Segment_tree.cpp
+++ b/Range Queries/Segment_tree.cpp
@@ -1,89 +1,60 @@
-// Credits to HealthyUG for the inspiration.
-// Segment Tree with Point Updates and Range Queries
-// Supports multiple Segment Trees with just a change in the Node and Update
-// Very few changes required everytime
+// Segment Tree — O(N) build, O(log N) point update and range query
+// Customise Node1 (merge logic, identity) and Update1 (apply logic) for your problem.
+// Example below: XOR with point-set updates.
+#include <bits/stdc++.h>
+using namespace std;
 
 template<typename Node, typename Update>
 struct SegTree {
-	vector<Node> tree;
-	vector<ll> arr; // type may change
-	int n;
-	int s;
-	SegTree(int a_len, vector<ll> &a) { // change if type updated
-		arr = a;
-		n = a_len;
-		s = 1;
-		while(s < 2 * n){
-			s = s << 1;
-		}
-		tree.resize(s); fill(all(tree), Node());
-		build(0, n - 1, 1);
-	}
-	void build(int start, int end, int index)  // Never change this
-	{
-		if (start == end)	{
-			tree[index] = Node(arr[start]);
-			return;
-		}
-		int mid = (start + end) / 2;
-		build(start, mid, 2 * index);
-		build(mid + 1, end, 2 * index + 1);
-		tree[index].merge(tree[2 * index], tree[2 * index + 1]);
-	}
-	void update(int start, int end, int index, int query_index, Update &u)  // Never Change this
-	{
-		if (start == end) {
-			u.apply(tree[index]);
-			return;
-		}
-		int mid = (start + end) / 2;
-		if (mid >= query_index)
-			update(start, mid, 2 * index, query_index, u);
-		else
-			update(mid + 1, end, 2 * index + 1, query_index, u);
-		tree[index].merge(tree[2 * index], tree[2 * index + 1]);
-	}
-	Node query(int start, int end, int index, int left, int right) { // Never change this
-		if (start > right || end < left)
-			return Node();
-		if (start >= left && end <= right)
-			return tree[index];
-		int mid = (start + end) / 2;
-		Node l, r, ans;
-		l = query(start, mid, 2 * index, left, right);
-		r = query(mid + 1, end, 2 * index + 1, left, right);
-		ans.merge(l, r);
-		return ans;
-	}
-	void make_update(int index, ll val) {  // pass in as many parameters as required
-		Update new_update = Update(val); // may change
-		update(0, n - 1, 1, index, new_update);
-	}
-	Node make_query(int left, int right) {
-		return query(0, n - 1, 1, left, right);
-	}
+    vector<Node> tree;
+    int n, s;
+
+    SegTree(int n, vector<long long>& a) : n(n), s(1) {
+        while (s < 2 * n) s <<= 1;
+        tree.resize(s, Node());
+        _build(a, 0, n - 1, 1);
+    }
+
+    void _build(vector<long long>& a, int l, int r, int idx) {
+        if (l == r) { tree[idx] = Node(a[l]); return; }
+        int m = (l + r) / 2;
+        _build(a, l, m, 2 * idx);
+        _build(a, m + 1, r, 2 * idx + 1);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
+    }
+
+    void _update(int l, int r, int idx, int pos, Update& u) {
+        if (l == r) { u.apply(tree[idx]); return; }
+        int m = (l + r) / 2;
+        if (pos <= m) _update(l, m, 2 * idx, pos, u);
+        else _update(m + 1, r, 2 * idx + 1, pos, u);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
+    }
+
+    Node _query(int l, int r, int idx, int ql, int qr) {
+        if (l > qr || r < ql) return Node();
+        if (l >= ql && r <= qr) return tree[idx];
+        int m = (l + r) / 2;
+        Node left = _query(l, m, 2 * idx, ql, qr);
+        Node right = _query(m + 1, r, 2 * idx + 1, ql, qr);
+        Node ans;
+        ans.merge(left, right);
+        return ans;
+    }
+
+    void make_update(int pos, long long val) { Update u(val); _update(0, n - 1, 1, pos, u); }
+    Node make_query(int l, int r) { return _query(0, n - 1, 1, l, r); }
 };
 
+// Example: XOR aggregate, point-set update
 struct Node1 {
-	ll val; // may change
-	Node1() { // Identity element
-		val = 0;	// may change
-	}
-	Node1(ll p1) {  // Actual Node
-		val = p1; // may change
-	}
-	void merge(Node1 &l, Node1 &r) { // Merge two child nodes
-		val = l.val ^ r.val;  // may change
-	}
+    long long val = 0;  // identity for XOR
+    Node1() = default;
+    Node1(long long v) : val(v) {}
+    void merge(const Node1& l, const Node1& r) { val = l.val ^ r.val; }
 };
-
 struct Update1 {
-	ll val; // may change
-	Update1(ll p1) { // Actual Update
-		val = p1; // may change
-	}
-	void apply(Node1 &a) { // apply update to given node
-		a.val = val; // may change
-	}
+    long long val;
+    Update1(long long v) : val(v) {}
+    void apply(Node1& a) { a.val = val; }
 };
-

--- a/Range Queries/Sparse_Table.cpp
+++ b/Range Queries/Sparse_Table.cpp
@@ -6,8 +6,8 @@ using namespace std;
 template<typename Node>
 struct SparseTable {
     vector<vector<Node>> table;
-    vector<long long> logVal;
     int n, maxLog;
+    vector<long long> logVal;
 
     SparseTable(int n, vector<long long>& a) : n(n), logVal(n + 1, 0) {
         maxLog = n > 1 ? (int)log2(n) : 0;

--- a/Range Queries/Sparse_Table.cpp
+++ b/Range Queries/Sparse_Table.cpp
@@ -1,65 +1,49 @@
-// O(1) for idempotent O(logN) for general
-// Supports multiple sparse tables with minor change in Node
+// Sparse Table — O(N log N) build; O(1) for idempotent queries (min/max), O(log N) for others
+// Customise Node1 (merge, identity) for your query type. Example: XOR (non-idempotent).
+#include <bits/stdc++.h>
+using namespace std;
 
 template<typename Node>
 struct SparseTable {
-	vector<vector<Node>> table;
-	vector<ll> logValues;
-	int n;
-	int maxLog;
-	vector<ll> a;
-	SparseTable(int n1, vector<ll> &arr) {
-		n = n1;
-		a = arr;
-		table.resize(n);
-		logValues.resize(n + 1);
-		maxLog = log2(n);
-		logValues[1] = 0;
-		for (int i = 2; i <= n; i++) {
-			logValues[i] = logValues[i / 2] + 1;
-		}
-		for (int i = 0; i < n; i++) {
-			table[i].resize(maxLog + 1);
-			fill(all(table[i]), Node());
-		}
-		build();
-	}
-	void build() {
-		for (int i = 0; i < n; i++) {
-			table[i][0] = Node(a[i]);
-		}
-		for (int i = 1; i <= maxLog; i++) {
-			for (int j = 0; (j + (1 << i)) <= n; j++) {
-				table[j][i].merge(table[j][i - 1], table[j + (1 << (i - 1))][i - 1]);
-			}
-		}
-	}
-	Node queryNormal(int left, int right) {
-		Node ans = Node();
-		for (int j = logValues[right - left + 1]; j >= 0; j--) {
-			if ((1 << j) <= right - left + 1) {
-				ans.merge(ans, table[left][j]);
-				left += (1 << j);
-			}
-		}
-		return ans;
-	}
-	Node queryIdempotent(int left, int right) {
-		int j = logValues[right - left + 1];
-		Node ans = Node();
-		ans.merge(table[left][j], table[right - (1 << j) + 1][j]);
-		return ans;
-	}
+    vector<vector<Node>> table;
+    vector<long long> logVal;
+    int n, maxLog;
+
+    SparseTable(int n, vector<long long>& a) : n(n), logVal(n + 1, 0) {
+        maxLog = n > 1 ? (int)log2(n) : 0;
+        for (int i = 2; i <= n; i++) logVal[i] = logVal[i / 2] + 1;
+        table.assign(n, vector<Node>(maxLog + 1, Node()));
+        for (int i = 0; i < n; i++) table[i][0] = Node(a[i]);
+        for (int j = 1; j <= maxLog; j++)
+            for (int i = 0; i + (1 << j) <= n; i++)
+                table[i][j].merge(table[i][j - 1], table[i + (1 << (j - 1))][j - 1]);
+    }
+
+    // For non-idempotent operations (e.g. XOR, sum): O(log N)
+    Node queryNormal(int l, int r) {
+        Node ans;
+        for (int j = logVal[r - l + 1]; j >= 0; j--) {
+            if ((1 << j) <= r - l + 1) {
+                ans.merge(ans, table[l][j]);
+                l += (1 << j);
+            }
+        }
+        return ans;
+    }
+
+    // For idempotent operations (e.g. min, max, gcd): O(1)
+    Node queryIdempotent(int l, int r) {
+        int j = logVal[r - l + 1];
+        Node ans;
+        ans.merge(table[l][j], table[r - (1 << j) + 1][j]);
+        return ans;
+    }
 };
+
+// Example: XOR aggregate (non-idempotent, use queryNormal)
 struct Node1 {
-	ll val; // store more info if required
-	Node1() { // Identity Element
-		val = 0;
-	}
-	Node1(ll v) {
-		val = v;
-	}
-	void merge(Node1 &l, Node1 &r) {
-		val = l.val ^ r.val;
-	}
+    long long val = 0;
+    Node1() = default;
+    Node1(long long v) : val(v) {}
+    void merge(const Node1& l, const Node1& r) { val = l.val ^ r.val; }
 };

--- a/tests/test_lazy_sgt.cpp
+++ b/tests/test_lazy_sgt.cpp
@@ -15,86 +15,124 @@ int run_tests() {
         vector<long long> a = {1, 2, 3, 4, 5};
         LazySGT<Node1, Update1> sgt(5, a);
 
-        ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
-        ASSERT_EQ(sgt.make_query(1, 3).val, 9LL);
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
 
         // Assign [1,3] = 10 → [1, 10, 10, 10, 5]
         sgt.make_update(1, 3, 10);
-        ASSERT_EQ(sgt.make_query(0, 4).val, 36LL);
-        ASSERT_EQ(sgt.make_query(1, 3).val, 30LL);
-        ASSERT_EQ(sgt.make_query(0, 0).val, 1LL);
-        ASSERT_EQ(sgt.make_query(4, 4).val, 5LL);
+        for (int i = 1; i <= 3; i++) a[i] = 10;
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+        ASSERT_EQ(sgt.make_query(4, 4).val, brute_sum(a, 4, 4));
 
         // Assign entire array = 3
         sgt.make_update(0, 4, 3);
-        ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
-        ASSERT_EQ(sgt.make_query(2, 4).val, 9LL);
+        for (int i = 0; i <= 4; i++) a[i] = 3;
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(2, 4).val, brute_sum(a, 2, 4));
     }
 
     // --- Single element array ---
     {
         vector<long long> a = {7};
         LazySGT<Node1, Update1> sgt(1, a);
-        ASSERT_EQ(sgt.make_query(0, 0).val, 7LL);
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
         sgt.make_update(0, 0, 100);
-        ASSERT_EQ(sgt.make_query(0, 0).val, 100LL);
+        a[0] = 100;
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
         sgt.make_update(0, 0, 0);
-        ASSERT_EQ(sgt.make_query(0, 0).val, 0LL);
+        a[0] = 0;
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
     }
 
     // --- All zeros, assign to non-zero ---
     {
         vector<long long> a(6, 0);
         LazySGT<Node1, Update1> sgt(6, a);
-        ASSERT_EQ(sgt.make_query(0, 5).val, 0LL);
+        ASSERT_EQ(sgt.make_query(0, 5).val, brute_sum(a, 0, 5));
         sgt.make_update(2, 4, 5);
-        ASSERT_EQ(sgt.make_query(0, 5).val, 15LL);
-        ASSERT_EQ(sgt.make_query(2, 4).val, 15LL);
-        ASSERT_EQ(sgt.make_query(0, 1).val, 0LL);
-        ASSERT_EQ(sgt.make_query(5, 5).val, 0LL);
+        for (int i = 2; i <= 4; i++) a[i] = 5;
+        ASSERT_EQ(sgt.make_query(0, 5).val, brute_sum(a, 0, 5));
+        ASSERT_EQ(sgt.make_query(2, 4).val, brute_sum(a, 2, 4));
+        ASSERT_EQ(sgt.make_query(0, 1).val, brute_sum(a, 0, 1));
+        ASSERT_EQ(sgt.make_query(5, 5).val, brute_sum(a, 5, 5));
     }
 
     // --- Overlapping range updates ---
     {
-        vector<long long> a = {0, 0, 0, 0, 0};
+        vector<long long> a(5, 0);
         LazySGT<Node1, Update1> sgt(5, a);
         sgt.make_update(0, 4, 10);
-        sgt.make_update(1, 3, 20);  // overwrites [1,3]
+        for (int i = 0; i <= 4; i++) a[i] = 10;
+        sgt.make_update(1, 3, 20);
+        for (int i = 1; i <= 3; i++) a[i] = 20;
         // array = [10, 20, 20, 20, 10]
-        ASSERT_EQ(sgt.make_query(0, 4).val, 80LL);
-        ASSERT_EQ(sgt.make_query(0, 0).val, 10LL);
-        ASSERT_EQ(sgt.make_query(1, 3).val, 60LL);
-        ASSERT_EQ(sgt.make_query(4, 4).val, 10LL);
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+        ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
+        ASSERT_EQ(sgt.make_query(4, 4).val, brute_sum(a, 4, 4));
     }
 
     // --- Nested range updates: outer then inner then outer again ---
     {
         vector<long long> a(8, 1);
         LazySGT<Node1, Update1> sgt(8, a);
-        sgt.make_update(0, 7, 5);   // all = 5, sum = 40
-        ASSERT_EQ(sgt.make_query(0, 7).val, 40LL);
-        sgt.make_update(2, 5, 3);   // [2,5]=3, sum = 5+5+3+3+3+3+5+5 = 32
-        ASSERT_EQ(sgt.make_query(0, 7).val, 32LL);
-        ASSERT_EQ(sgt.make_query(2, 5).val, 12LL);
-        sgt.make_update(0, 7, 7);   // all = 7, sum = 56
-        ASSERT_EQ(sgt.make_query(0, 7).val, 56LL);
-        ASSERT_EQ(sgt.make_query(3, 3).val, 7LL);
+        sgt.make_update(0, 7, 5);
+        for (int i = 0; i <= 7; i++) a[i] = 5;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        sgt.make_update(2, 5, 3);
+        for (int i = 2; i <= 5; i++) a[i] = 3;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        ASSERT_EQ(sgt.make_query(2, 5).val, brute_sum(a, 2, 5));
+        sgt.make_update(0, 7, 7);
+        for (int i = 0; i <= 7; i++) a[i] = 7;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        ASSERT_EQ(sgt.make_query(3, 3).val, brute_sum(a, 3, 3));
     }
 
     // --- Power-of-two size ---
     {
         vector<long long> a = {1, 2, 3, 4, 5, 6, 7, 8};
         LazySGT<Node1, Update1> sgt(8, a);
-        ASSERT_EQ(sgt.make_query(0, 7).val, 36LL);
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
         sgt.make_update(4, 7, 0);
-        ASSERT_EQ(sgt.make_query(0, 7).val, 10LL);
-        ASSERT_EQ(sgt.make_query(4, 7).val, 0LL);
-        ASSERT_EQ(sgt.make_query(0, 3).val, 10LL);
+        for (int i = 4; i <= 7; i++) a[i] = 0;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        ASSERT_EQ(sgt.make_query(4, 7).val, brute_sum(a, 4, 7));
+        ASSERT_EQ(sgt.make_query(0, 3).val, brute_sum(a, 0, 3));
+    }
+
+    // --- Consecutive full-array reassignments ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5, 6, 7};
+        LazySGT<Node1, Update1> sgt(7, a);
+        for (long long v = 1; v <= 10; v++) {
+            sgt.make_update(0, 6, v);
+            for (int i = 0; i <= 6; i++) a[i] = v;
+            ASSERT_EQ(sgt.make_query(0, 6).val, brute_sum(a, 0, 6));
+        }
+    }
+
+    // --- Point-level assigns via single-index range update ---
+    {
+        vector<long long> a(5, 0);
+        LazySGT<Node1, Update1> sgt(5, a);
+        sgt.make_update(2, 2, 99);
+        a[2] = 99;
+        ASSERT_EQ(sgt.make_query(2, 2).val, brute_sum(a, 2, 2));
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        sgt.make_update(0, 0, 1);
+        a[0] = 1;
+        sgt.make_update(4, 4, 1);
+        a[4] = 1;
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
     }
 
     // --- Stress test: n=300, random range-assign + range-sum queries ---
     {
-        mt19937 rng(42);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         const int n = 300;
         vector<long long> a(n, 0);
         LazySGT<Node1, Update1> sgt(n, a);
@@ -108,32 +146,12 @@ int run_tests() {
                 for (int i = l; i <= r; i++) a[i] = val;
                 sgt.make_update(l, r, val);
             } else {
+                long long got = sgt.make_query(l, r).val;
                 long long expected = brute_sum(a, l, r);
-                ASSERT_EQ(sgt.make_query(l, r).val, expected);
+                if (got != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
+                ASSERT_EQ(got, expected);
             }
         }
-    }
-
-    // --- Consecutive full-array reassignments ---
-    {
-        vector<long long> a = {1, 2, 3, 4, 5, 6, 7};
-        LazySGT<Node1, Update1> sgt(7, a);
-        for (long long v = 1; v <= 10; v++) {
-            sgt.make_update(0, 6, v);
-            ASSERT_EQ(sgt.make_query(0, 6).val, v * 7);
-        }
-    }
-
-    // --- Point-level assigns via single-index range update ---
-    {
-        vector<long long> a = {0, 0, 0, 0, 0};
-        LazySGT<Node1, Update1> sgt(5, a);
-        sgt.make_update(2, 2, 99);
-        ASSERT_EQ(sgt.make_query(2, 2).val, 99LL);
-        ASSERT_EQ(sgt.make_query(0, 4).val, 99LL);
-        sgt.make_update(0, 0, 1);
-        sgt.make_update(4, 4, 1);
-        ASSERT_EQ(sgt.make_query(0, 4).val, 101LL);
     }
 
     TEST_PASS();

--- a/tests/test_lazy_sgt.cpp
+++ b/tests/test_lazy_sgt.cpp
@@ -1,0 +1,31 @@
+#include "common.h"
+#include "../Range Queries/Lazy_SGT.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Array [1, 2, 3, 4, 5], Node1 uses sum, Update1 is range assign
+    vector<long long> a = {1, 2, 3, 4, 5};
+    LazySGT<Node1, Update1> sgt(5, a);
+
+    // Sum of [0,4] = 15
+    ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
+
+    // Sum of [1,3] = 2+3+4 = 9
+    ASSERT_EQ(sgt.make_query(1, 3).val, 9LL);
+
+    // Range assign [1,3] = 10 → array [1, 10, 10, 10, 5]
+    sgt.make_update(1, 3, 10);
+    ASSERT_EQ(sgt.make_query(0, 4).val, 36LL);  // 1+10+10+10+5
+    ASSERT_EQ(sgt.make_query(1, 3).val, 30LL);  // 10+10+10
+    ASSERT_EQ(sgt.make_query(0, 0).val, 1LL);   // unchanged
+    ASSERT_EQ(sgt.make_query(4, 4).val, 5LL);   // unchanged
+
+    // Range assign [0,4] = 3 → array [3, 3, 3, 3, 3]
+    sgt.make_update(0, 4, 3);
+    ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_lazy_sgt.cpp
+++ b/tests/test_lazy_sgt.cpp
@@ -3,27 +3,138 @@
 
 using namespace std;
 
+long long brute_sum(vector<long long>& a, int l, int r) {
+    long long res = 0;
+    for (int i = l; i <= r; i++) res += a[i];
+    return res;
+}
+
 int run_tests() {
-    // Array [1, 2, 3, 4, 5], Node1 uses sum, Update1 is range assign
-    vector<long long> a = {1, 2, 3, 4, 5};
-    LazySGT<Node1, Update1> sgt(5, a);
+    // --- Small test: [1, 2, 3, 4, 5], range-assign, range-sum ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5};
+        LazySGT<Node1, Update1> sgt(5, a);
 
-    // Sum of [0,4] = 15
-    ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
+        ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
+        ASSERT_EQ(sgt.make_query(1, 3).val, 9LL);
 
-    // Sum of [1,3] = 2+3+4 = 9
-    ASSERT_EQ(sgt.make_query(1, 3).val, 9LL);
+        // Assign [1,3] = 10 → [1, 10, 10, 10, 5]
+        sgt.make_update(1, 3, 10);
+        ASSERT_EQ(sgt.make_query(0, 4).val, 36LL);
+        ASSERT_EQ(sgt.make_query(1, 3).val, 30LL);
+        ASSERT_EQ(sgt.make_query(0, 0).val, 1LL);
+        ASSERT_EQ(sgt.make_query(4, 4).val, 5LL);
 
-    // Range assign [1,3] = 10 → array [1, 10, 10, 10, 5]
-    sgt.make_update(1, 3, 10);
-    ASSERT_EQ(sgt.make_query(0, 4).val, 36LL);  // 1+10+10+10+5
-    ASSERT_EQ(sgt.make_query(1, 3).val, 30LL);  // 10+10+10
-    ASSERT_EQ(sgt.make_query(0, 0).val, 1LL);   // unchanged
-    ASSERT_EQ(sgt.make_query(4, 4).val, 5LL);   // unchanged
+        // Assign entire array = 3
+        sgt.make_update(0, 4, 3);
+        ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
+        ASSERT_EQ(sgt.make_query(2, 4).val, 9LL);
+    }
 
-    // Range assign [0,4] = 3 → array [3, 3, 3, 3, 3]
-    sgt.make_update(0, 4, 3);
-    ASSERT_EQ(sgt.make_query(0, 4).val, 15LL);
+    // --- Single element array ---
+    {
+        vector<long long> a = {7};
+        LazySGT<Node1, Update1> sgt(1, a);
+        ASSERT_EQ(sgt.make_query(0, 0).val, 7LL);
+        sgt.make_update(0, 0, 100);
+        ASSERT_EQ(sgt.make_query(0, 0).val, 100LL);
+        sgt.make_update(0, 0, 0);
+        ASSERT_EQ(sgt.make_query(0, 0).val, 0LL);
+    }
+
+    // --- All zeros, assign to non-zero ---
+    {
+        vector<long long> a(6, 0);
+        LazySGT<Node1, Update1> sgt(6, a);
+        ASSERT_EQ(sgt.make_query(0, 5).val, 0LL);
+        sgt.make_update(2, 4, 5);
+        ASSERT_EQ(sgt.make_query(0, 5).val, 15LL);
+        ASSERT_EQ(sgt.make_query(2, 4).val, 15LL);
+        ASSERT_EQ(sgt.make_query(0, 1).val, 0LL);
+        ASSERT_EQ(sgt.make_query(5, 5).val, 0LL);
+    }
+
+    // --- Overlapping range updates ---
+    {
+        vector<long long> a = {0, 0, 0, 0, 0};
+        LazySGT<Node1, Update1> sgt(5, a);
+        sgt.make_update(0, 4, 10);
+        sgt.make_update(1, 3, 20);  // overwrites [1,3]
+        // array = [10, 20, 20, 20, 10]
+        ASSERT_EQ(sgt.make_query(0, 4).val, 80LL);
+        ASSERT_EQ(sgt.make_query(0, 0).val, 10LL);
+        ASSERT_EQ(sgt.make_query(1, 3).val, 60LL);
+        ASSERT_EQ(sgt.make_query(4, 4).val, 10LL);
+    }
+
+    // --- Nested range updates: outer then inner then outer again ---
+    {
+        vector<long long> a(8, 1);
+        LazySGT<Node1, Update1> sgt(8, a);
+        sgt.make_update(0, 7, 5);   // all = 5, sum = 40
+        ASSERT_EQ(sgt.make_query(0, 7).val, 40LL);
+        sgt.make_update(2, 5, 3);   // [2,5]=3, sum = 5+5+3+3+3+3+5+5 = 32
+        ASSERT_EQ(sgt.make_query(0, 7).val, 32LL);
+        ASSERT_EQ(sgt.make_query(2, 5).val, 12LL);
+        sgt.make_update(0, 7, 7);   // all = 7, sum = 56
+        ASSERT_EQ(sgt.make_query(0, 7).val, 56LL);
+        ASSERT_EQ(sgt.make_query(3, 3).val, 7LL);
+    }
+
+    // --- Power-of-two size ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5, 6, 7, 8};
+        LazySGT<Node1, Update1> sgt(8, a);
+        ASSERT_EQ(sgt.make_query(0, 7).val, 36LL);
+        sgt.make_update(4, 7, 0);
+        ASSERT_EQ(sgt.make_query(0, 7).val, 10LL);
+        ASSERT_EQ(sgt.make_query(4, 7).val, 0LL);
+        ASSERT_EQ(sgt.make_query(0, 3).val, 10LL);
+    }
+
+    // --- Stress test: n=300, random range-assign + range-sum queries ---
+    {
+        mt19937 rng(42);
+        const int n = 300;
+        vector<long long> a(n, 0);
+        LazySGT<Node1, Update1> sgt(n, a);
+
+        for (int iter = 0; iter < 600; iter++) {
+            int l = rng() % n;
+            int r = rng() % n;
+            if (l > r) swap(l, r);
+            if (rng() % 2 == 0) {
+                long long val = rng() % 1000;
+                for (int i = l; i <= r; i++) a[i] = val;
+                sgt.make_update(l, r, val);
+            } else {
+                long long expected = brute_sum(a, l, r);
+                ASSERT_EQ(sgt.make_query(l, r).val, expected);
+            }
+        }
+    }
+
+    // --- Consecutive full-array reassignments ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5, 6, 7};
+        LazySGT<Node1, Update1> sgt(7, a);
+        for (long long v = 1; v <= 10; v++) {
+            sgt.make_update(0, 6, v);
+            ASSERT_EQ(sgt.make_query(0, 6).val, v * 7);
+        }
+    }
+
+    // --- Point-level assigns via single-index range update ---
+    {
+        vector<long long> a = {0, 0, 0, 0, 0};
+        LazySGT<Node1, Update1> sgt(5, a);
+        sgt.make_update(2, 2, 99);
+        ASSERT_EQ(sgt.make_query(2, 2).val, 99LL);
+        ASSERT_EQ(sgt.make_query(0, 4).val, 99LL);
+        sgt.make_update(0, 0, 1);
+        sgt.make_update(4, 4, 1);
+        ASSERT_EQ(sgt.make_query(0, 4).val, 101LL);
+    }
 
     TEST_PASS();
 }

--- a/tests/test_mo_algo.cpp
+++ b/tests/test_mo_algo.cpp
@@ -1,0 +1,25 @@
+#include "common.h"
+#include "../Range Queries/Mo_algo.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // arr = [1, 2, 3, 2, 1, 4, 3]
+    // Queries (0-indexed, inclusive):
+    //   (0, 2) → {1,2,3} → 3 distinct
+    //   (1, 4) → {2,3,2,1} → {1,2,3} → 3 distinct
+    //   (0, 6) → all → {1,2,3,4} → 4 distinct
+    //   (3, 5) → {2,1,4} → 3 distinct
+    vector<int> arr = {1, 2, 3, 2, 1, 4, 3};
+    vector<pair<int, int>> queries = {{0, 2}, {1, 4}, {0, 6}, {3, 5}};
+
+    vector<int> ans = moDistinctQueries(7, arr, queries);
+    ASSERT_EQ(ans[0], 3);
+    ASSERT_EQ(ans[1], 3);
+    ASSERT_EQ(ans[2], 4);
+    ASSERT_EQ(ans[3], 3);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_mo_algo.cpp
+++ b/tests/test_mo_algo.cpp
@@ -3,21 +3,139 @@
 
 using namespace std;
 
-int run_tests() {
-    // arr = [1, 2, 3, 2, 1, 4, 3]
-    // Queries (0-indexed, inclusive):
-    //   (0, 2) → {1,2,3} → 3 distinct
-    //   (1, 4) → {2,3,2,1} → {1,2,3} → 3 distinct
-    //   (0, 6) → all → {1,2,3,4} → 4 distinct
-    //   (3, 5) → {2,1,4} → 3 distinct
-    vector<int> arr = {1, 2, 3, 2, 1, 4, 3};
-    vector<pair<int, int>> queries = {{0, 2}, {1, 4}, {0, 6}, {3, 5}};
+int brute_distinct(vector<int>& arr, int l, int r) {
+    set<int> s(arr.begin() + l, arr.begin() + r + 1);
+    return (int)s.size();
+}
 
-    vector<int> ans = moDistinctQueries(7, arr, queries);
-    ASSERT_EQ(ans[0], 3);
-    ASSERT_EQ(ans[1], 3);
-    ASSERT_EQ(ans[2], 4);
-    ASSERT_EQ(ans[3], 3);
+int run_tests() {
+    // --- Small test: [1, 2, 3, 2, 1, 4, 3] ---
+    {
+        vector<int> arr = {1, 2, 3, 2, 1, 4, 3};
+        vector<pair<int, int>> queries = {{0, 2}, {1, 4}, {0, 6}, {3, 5}};
+        vector<int> ans = moDistinctQueries(7, arr, queries);
+        ASSERT_EQ(ans[0], 3);  // {1,2,3}
+        ASSERT_EQ(ans[1], 3);  // {1,2,3}
+        ASSERT_EQ(ans[2], 4);  // {1,2,3,4}
+        ASSERT_EQ(ans[3], 3);  // {1,2,4}
+    }
+
+    // --- Single element queries ---
+    {
+        vector<int> arr = {5, 5, 5, 5};
+        vector<pair<int, int>> queries = {{0, 0}, {1, 1}, {2, 3}};
+        vector<int> ans = moDistinctQueries(4, arr, queries);
+        ASSERT_EQ(ans[0], 1);
+        ASSERT_EQ(ans[1], 1);
+        ASSERT_EQ(ans[2], 1);
+    }
+
+    // --- All distinct elements ---
+    {
+        vector<int> arr = {10, 20, 30, 40, 50};
+        vector<pair<int, int>> queries = {{0, 4}, {0, 2}, {2, 4}, {1, 3}};
+        vector<int> ans = moDistinctQueries(5, arr, queries);
+        ASSERT_EQ(ans[0], 5);
+        ASSERT_EQ(ans[1], 3);
+        ASSERT_EQ(ans[2], 3);
+        ASSERT_EQ(ans[3], 3);
+    }
+
+    // --- All same elements ---
+    {
+        vector<int> arr = {7, 7, 7, 7, 7, 7};
+        vector<pair<int, int>> queries = {{0, 5}, {0, 0}, {2, 4}, {1, 5}};
+        vector<int> ans = moDistinctQueries(6, arr, queries);
+        ASSERT_EQ(ans[0], 1);
+        ASSERT_EQ(ans[1], 1);
+        ASSERT_EQ(ans[2], 1);
+        ASSERT_EQ(ans[3], 1);
+    }
+
+    // --- Two elements alternating ---
+    {
+        vector<int> arr = {1, 2, 1, 2, 1, 2};
+        vector<pair<int, int>> queries = {{0, 5}, {0, 0}, {0, 1}, {1, 4}};
+        vector<int> ans = moDistinctQueries(6, arr, queries);
+        ASSERT_EQ(ans[0], 2);
+        ASSERT_EQ(ans[1], 1);
+        ASSERT_EQ(ans[2], 2);
+        ASSERT_EQ(ans[3], 2);
+    }
+
+    // --- Large values (no coordinate compression issues) ---
+    {
+        vector<int> arr = {1000000, 999999, 1000000, 999998, 999999};
+        vector<pair<int, int>> queries = {{0, 4}, {0, 2}, {1, 3}};
+        vector<int> ans = moDistinctQueries(5, arr, queries);
+        ASSERT_EQ(ans[0], 3);  // {999998, 999999, 1000000}
+        ASSERT_EQ(ans[1], 2);  // {999999, 1000000}
+        ASSERT_EQ(ans[2], 3);  // {999998, 999999, 1000000}
+    }
+
+    // --- Single query spanning full array ---
+    {
+        vector<int> arr = {3, 1, 4, 1, 5, 9, 2, 6};
+        vector<pair<int, int>> queries = {{0, 7}};
+        vector<int> ans = moDistinctQueries(8, arr, queries);
+        ASSERT_EQ(ans[0], 7);  // {1,2,3,4,5,6,9}
+    }
+
+    // --- Many queries on same range (order preserved) ---
+    {
+        vector<int> arr = {1, 2, 3};
+        vector<pair<int, int>> queries = {{0, 2}, {0, 2}, {0, 2}};
+        vector<int> ans = moDistinctQueries(3, arr, queries);
+        ASSERT_EQ(ans[0], 3);
+        ASSERT_EQ(ans[1], 3);
+        ASSERT_EQ(ans[2], 3);
+    }
+
+    // --- Stress test: n=500, q=200, random queries verified by brute force ---
+    {
+        mt19937 rng(99);
+        const int n = 500;
+        vector<int> arr(n);
+        for (int i = 0; i < n; i++) arr[i] = rng() % 50;  // values in [0,49]
+
+        const int q = 200;
+        vector<pair<int, int>> queries(q);
+        for (int i = 0; i < q; i++) {
+            int l = rng() % n;
+            int r = rng() % n;
+            if (l > r) swap(l, r);
+            queries[i] = {l, r};
+        }
+
+        vector<int> ans = moDistinctQueries(n, arr, queries);
+        for (int i = 0; i < q; i++) {
+            int expected = brute_distinct(arr, queries[i].first, queries[i].second);
+            ASSERT_EQ(ans[i], expected);
+        }
+    }
+
+    // --- Stress test: n=300, q=300, large value range ---
+    {
+        mt19937 rng(77);
+        const int n = 300;
+        vector<int> arr(n);
+        for (int i = 0; i < n; i++) arr[i] = rng() % 1000000;
+
+        const int q = 300;
+        vector<pair<int, int>> queries(q);
+        for (int i = 0; i < q; i++) {
+            int l = rng() % n;
+            int r = rng() % n;
+            if (l > r) swap(l, r);
+            queries[i] = {l, r};
+        }
+
+        vector<int> ans = moDistinctQueries(n, arr, queries);
+        for (int i = 0; i < q; i++) {
+            int expected = brute_distinct(arr, queries[i].first, queries[i].second);
+            ASSERT_EQ(ans[i], expected);
+        }
+    }
 
     TEST_PASS();
 }

--- a/tests/test_mo_algo.cpp
+++ b/tests/test_mo_algo.cpp
@@ -14,10 +14,10 @@ int run_tests() {
         vector<int> arr = {1, 2, 3, 2, 1, 4, 3};
         vector<pair<int, int>> queries = {{0, 2}, {1, 4}, {0, 6}, {3, 5}};
         vector<int> ans = moDistinctQueries(7, arr, queries);
-        ASSERT_EQ(ans[0], 3);  // {1,2,3}
-        ASSERT_EQ(ans[1], 3);  // {1,2,3}
-        ASSERT_EQ(ans[2], 4);  // {1,2,3,4}
-        ASSERT_EQ(ans[3], 3);  // {1,2,4}
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 1, 4));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 0, 6));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 3, 5));
     }
 
     // --- Single element queries ---
@@ -25,9 +25,9 @@ int run_tests() {
         vector<int> arr = {5, 5, 5, 5};
         vector<pair<int, int>> queries = {{0, 0}, {1, 1}, {2, 3}};
         vector<int> ans = moDistinctQueries(4, arr, queries);
-        ASSERT_EQ(ans[0], 1);
-        ASSERT_EQ(ans[1], 1);
-        ASSERT_EQ(ans[2], 1);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 0));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 1, 1));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 2, 3));
     }
 
     // --- All distinct elements ---
@@ -35,10 +35,10 @@ int run_tests() {
         vector<int> arr = {10, 20, 30, 40, 50};
         vector<pair<int, int>> queries = {{0, 4}, {0, 2}, {2, 4}, {1, 3}};
         vector<int> ans = moDistinctQueries(5, arr, queries);
-        ASSERT_EQ(ans[0], 5);
-        ASSERT_EQ(ans[1], 3);
-        ASSERT_EQ(ans[2], 3);
-        ASSERT_EQ(ans[3], 3);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 4));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 2, 4));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 1, 3));
     }
 
     // --- All same elements ---
@@ -46,10 +46,10 @@ int run_tests() {
         vector<int> arr = {7, 7, 7, 7, 7, 7};
         vector<pair<int, int>> queries = {{0, 5}, {0, 0}, {2, 4}, {1, 5}};
         vector<int> ans = moDistinctQueries(6, arr, queries);
-        ASSERT_EQ(ans[0], 1);
-        ASSERT_EQ(ans[1], 1);
-        ASSERT_EQ(ans[2], 1);
-        ASSERT_EQ(ans[3], 1);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 5));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 0));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 2, 4));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 1, 5));
     }
 
     // --- Two elements alternating ---
@@ -57,20 +57,20 @@ int run_tests() {
         vector<int> arr = {1, 2, 1, 2, 1, 2};
         vector<pair<int, int>> queries = {{0, 5}, {0, 0}, {0, 1}, {1, 4}};
         vector<int> ans = moDistinctQueries(6, arr, queries);
-        ASSERT_EQ(ans[0], 2);
-        ASSERT_EQ(ans[1], 1);
-        ASSERT_EQ(ans[2], 2);
-        ASSERT_EQ(ans[3], 2);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 5));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 0));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 0, 1));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 1, 4));
     }
 
-    // --- Large values (no coordinate compression issues) ---
+    // --- Large values (coordinate compression must handle these) ---
     {
         vector<int> arr = {1000000, 999999, 1000000, 999998, 999999};
         vector<pair<int, int>> queries = {{0, 4}, {0, 2}, {1, 3}};
         vector<int> ans = moDistinctQueries(5, arr, queries);
-        ASSERT_EQ(ans[0], 3);  // {999998, 999999, 1000000}
-        ASSERT_EQ(ans[1], 2);  // {999999, 1000000}
-        ASSERT_EQ(ans[2], 3);  // {999998, 999999, 1000000}
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 4));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 1, 3));
     }
 
     // --- Single query spanning full array ---
@@ -78,7 +78,7 @@ int run_tests() {
         vector<int> arr = {3, 1, 4, 1, 5, 9, 2, 6};
         vector<pair<int, int>> queries = {{0, 7}};
         vector<int> ans = moDistinctQueries(8, arr, queries);
-        ASSERT_EQ(ans[0], 7);  // {1,2,3,4,5,6,9}
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 7));
     }
 
     // --- Many queries on same range (order preserved) ---
@@ -86,23 +86,23 @@ int run_tests() {
         vector<int> arr = {1, 2, 3};
         vector<pair<int, int>> queries = {{0, 2}, {0, 2}, {0, 2}};
         vector<int> ans = moDistinctQueries(3, arr, queries);
-        ASSERT_EQ(ans[0], 3);
-        ASSERT_EQ(ans[1], 3);
-        ASSERT_EQ(ans[2], 3);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 0, 2));
     }
 
-    // --- Stress test: n=500, q=200, random queries verified by brute force ---
+    // --- Stress test: n=500, q=200, values in [0,49] ---
     {
-        mt19937 rng(99);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         const int n = 500;
         vector<int> arr(n);
-        for (int i = 0; i < n; i++) arr[i] = rng() % 50;  // values in [0,49]
+        for (int i = 0; i < n; i++) arr[i] = rng() % 50;
 
         const int q = 200;
         vector<pair<int, int>> queries(q);
         for (int i = 0; i < q; i++) {
-            int l = rng() % n;
-            int r = rng() % n;
+            int l = rng() % n, r = rng() % n;
             if (l > r) swap(l, r);
             queries[i] = {l, r};
         }
@@ -110,13 +110,15 @@ int run_tests() {
         vector<int> ans = moDistinctQueries(n, arr, queries);
         for (int i = 0; i < q; i++) {
             int expected = brute_distinct(arr, queries[i].first, queries[i].second);
+            if (ans[i] != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
             ASSERT_EQ(ans[i], expected);
         }
     }
 
     // --- Stress test: n=300, q=300, large value range ---
     {
-        mt19937 rng(77);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         const int n = 300;
         vector<int> arr(n);
         for (int i = 0; i < n; i++) arr[i] = rng() % 1000000;
@@ -124,8 +126,7 @@ int run_tests() {
         const int q = 300;
         vector<pair<int, int>> queries(q);
         for (int i = 0; i < q; i++) {
-            int l = rng() % n;
-            int r = rng() % n;
+            int l = rng() % n, r = rng() % n;
             if (l > r) swap(l, r);
             queries[i] = {l, r};
         }
@@ -133,6 +134,7 @@ int run_tests() {
         vector<int> ans = moDistinctQueries(n, arr, queries);
         for (int i = 0; i < q; i++) {
             int expected = brute_distinct(arr, queries[i].first, queries[i].second);
+            if (ans[i] != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
             ASSERT_EQ(ans[i], expected);
         }
     }

--- a/tests/test_segment_tree.cpp
+++ b/tests/test_segment_tree.cpp
@@ -1,0 +1,30 @@
+#include "common.h"
+#include "../Range Queries/Segment_tree.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Array [1, 2, 3, 4, 5], Node1 uses XOR merge, Update1 sets value
+    vector<long long> a = {1, 2, 3, 4, 5};
+    SegTree<Node1, Update1> st(5, a);
+
+    // XOR of [0,4] = 1^2^3^4^5 = 1
+    ASSERT_EQ(st.make_query(0, 4).val, 1LL);
+
+    // XOR of [1,3] = 2^3^4 = 5
+    ASSERT_EQ(st.make_query(1, 3).val, 5LL);
+
+    // Point update: set index 2 to 7
+    // Array becomes [1, 2, 7, 4, 5], XOR = 1^2^7^4^5 = 5
+    st.make_update(2, 7);
+    ASSERT_EQ(st.make_query(0, 4).val, 5LL);
+    ASSERT_EQ(st.make_query(2, 2).val, 7LL);
+
+    // Single element query
+    ASSERT_EQ(st.make_query(0, 0).val, 1LL);
+    ASSERT_EQ(st.make_query(4, 4).val, 5LL);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_segment_tree.cpp
+++ b/tests/test_segment_tree.cpp
@@ -3,26 +3,130 @@
 
 using namespace std;
 
+long long brute_xor(vector<long long>& a, int l, int r) {
+    long long res = 0;
+    for (int i = l; i <= r; i++) res ^= a[i];
+    return res;
+}
+
 int run_tests() {
-    // Array [1, 2, 3, 4, 5], Node1 uses XOR merge, Update1 sets value
-    vector<long long> a = {1, 2, 3, 4, 5};
-    SegTree<Node1, Update1> st(5, a);
+    // --- Small test: [1, 2, 3, 4, 5], XOR merge, point-set update ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5};
+        SegTree<Node1, Update1> st(5, a);
 
-    // XOR of [0,4] = 1^2^3^4^5 = 1
-    ASSERT_EQ(st.make_query(0, 4).val, 1LL);
+        ASSERT_EQ(st.make_query(0, 4).val, 1LL);   // 1^2^3^4^5 = 1
+        ASSERT_EQ(st.make_query(1, 3).val, 5LL);   // 2^3^4 = 5
+        ASSERT_EQ(st.make_query(0, 0).val, 1LL);
+        ASSERT_EQ(st.make_query(4, 4).val, 5LL);
 
-    // XOR of [1,3] = 2^3^4 = 5
-    ASSERT_EQ(st.make_query(1, 3).val, 5LL);
+        // Point update: set index 2 → 7; array = [1, 2, 7, 4, 5]
+        st.make_update(2, 7);
+        ASSERT_EQ(st.make_query(0, 4).val, 5LL);   // 1^2^7^4^5 = 5
+        ASSERT_EQ(st.make_query(2, 2).val, 7LL);
+        ASSERT_EQ(st.make_query(1, 3).val, 1LL);   // 2^7^4 = 1
+    }
 
-    // Point update: set index 2 to 7
-    // Array becomes [1, 2, 7, 4, 5], XOR = 1^2^7^4^5 = 5
-    st.make_update(2, 7);
-    ASSERT_EQ(st.make_query(0, 4).val, 5LL);
-    ASSERT_EQ(st.make_query(2, 2).val, 7LL);
+    // --- Single element array ---
+    {
+        vector<long long> a = {42};
+        SegTree<Node1, Update1> st(1, a);
+        ASSERT_EQ(st.make_query(0, 0).val, 42LL);
+        st.make_update(0, 99);
+        ASSERT_EQ(st.make_query(0, 0).val, 99LL);
+    }
 
-    // Single element query
-    ASSERT_EQ(st.make_query(0, 0).val, 1LL);
-    ASSERT_EQ(st.make_query(4, 4).val, 5LL);
+    // --- Two element array ---
+    {
+        vector<long long> a = {5, 3};
+        SegTree<Node1, Update1> st(2, a);
+        ASSERT_EQ(st.make_query(0, 1).val, 6LL);   // 5^3 = 6
+        ASSERT_EQ(st.make_query(0, 0).val, 5LL);
+        ASSERT_EQ(st.make_query(1, 1).val, 3LL);
+        st.make_update(0, 3);
+        ASSERT_EQ(st.make_query(0, 1).val, 0LL);   // 3^3 = 0
+    }
+
+    // --- All-same values ---
+    {
+        vector<long long> a(8, 7);
+        SegTree<Node1, Update1> st(8, a);
+        ASSERT_EQ(st.make_query(0, 7).val, 0LL);   // 7^7^7^7^7^7^7^7 = 0 (even count)
+        ASSERT_EQ(st.make_query(0, 6).val, 7LL);   // odd count → 7
+        ASSERT_EQ(st.make_query(2, 4).val, 7LL);   // 7^7^7 = 7
+    }
+
+    // --- All zeros ---
+    {
+        vector<long long> a(6, 0);
+        SegTree<Node1, Update1> st(6, a);
+        ASSERT_EQ(st.make_query(0, 5).val, 0LL);
+        st.make_update(3, 15);
+        ASSERT_EQ(st.make_query(0, 5).val, 15LL);
+        ASSERT_EQ(st.make_query(3, 3).val, 15LL);
+        ASSERT_EQ(st.make_query(0, 2).val, 0LL);
+    }
+
+    // --- Power-of-two size (n=8) ---
+    {
+        vector<long long> a = {1, 2, 4, 8, 16, 32, 64, 128};
+        SegTree<Node1, Update1> st(8, a);
+        ASSERT_EQ(st.make_query(0, 7).val, brute_xor(a, 0, 7));
+        ASSERT_EQ(st.make_query(3, 6).val, brute_xor(a, 3, 6));
+        st.make_update(5, 0);
+        a[5] = 0;
+        ASSERT_EQ(st.make_query(0, 7).val, brute_xor(a, 0, 7));
+    }
+
+    // --- Stress test: n=300, random point updates and range XOR queries ---
+    {
+        mt19937 rng(7);
+        const int n = 300;
+        vector<long long> a(n);
+        for (int i = 0; i < n; i++) a[i] = rng() % 1000000;
+
+        SegTree<Node1, Update1> st(n, a);
+
+        for (int iter = 0; iter < 600; iter++) {
+            if (rng() % 2 == 0) {
+                // Random point update
+                int pos = rng() % n;
+                long long val = rng() % 1000000;
+                a[pos] = val;
+                st.make_update(pos, val);
+            } else {
+                // Random range XOR query
+                int l = rng() % n;
+                int r = rng() % n;
+                if (l > r) swap(l, r);
+                long long expected = brute_xor(a, l, r);
+                ASSERT_EQ(st.make_query(l, r).val, expected);
+            }
+        }
+    }
+
+    // --- Stress test: n=1 repeatedly updated ---
+    {
+        mt19937 rng(13);
+        vector<long long> a = {0};
+        SegTree<Node1, Update1> st(1, a);
+        for (int i = 0; i < 100; i++) {
+            long long v = rng() % 100000;
+            st.make_update(0, v);
+            ASSERT_EQ(st.make_query(0, 0).val, v);
+        }
+    }
+
+    // --- Consecutive updates to same position ---
+    {
+        vector<long long> a = {10, 20, 30};
+        SegTree<Node1, Update1> st(3, a);
+        st.make_update(1, 5);
+        ASSERT_EQ(st.make_query(1, 1).val, 5LL);
+        st.make_update(1, 100);
+        ASSERT_EQ(st.make_query(1, 1).val, 100LL);
+        ASSERT_EQ(st.make_query(0, 2).val, (10LL ^ 100LL ^ 30LL));
+    }
 
     TEST_PASS();
 }

--- a/tests/test_segment_tree.cpp
+++ b/tests/test_segment_tree.cpp
@@ -15,56 +15,60 @@ int run_tests() {
         vector<long long> a = {1, 2, 3, 4, 5};
         SegTree<Node1, Update1> st(5, a);
 
-        ASSERT_EQ(st.make_query(0, 4).val, 1LL);   // 1^2^3^4^5 = 1
-        ASSERT_EQ(st.make_query(1, 3).val, 5LL);   // 2^3^4 = 5
-        ASSERT_EQ(st.make_query(0, 0).val, 1LL);
-        ASSERT_EQ(st.make_query(4, 4).val, 5LL);
+        ASSERT_EQ(st.make_query(0, 4).val, brute_xor(a, 0, 4));
+        ASSERT_EQ(st.make_query(1, 3).val, brute_xor(a, 1, 3));
+        ASSERT_EQ(st.make_query(0, 0).val, brute_xor(a, 0, 0));
+        ASSERT_EQ(st.make_query(4, 4).val, brute_xor(a, 4, 4));
 
-        // Point update: set index 2 → 7; array = [1, 2, 7, 4, 5]
+        // Point update: set index 2 → 7
         st.make_update(2, 7);
-        ASSERT_EQ(st.make_query(0, 4).val, 5LL);   // 1^2^7^4^5 = 5
-        ASSERT_EQ(st.make_query(2, 2).val, 7LL);
-        ASSERT_EQ(st.make_query(1, 3).val, 1LL);   // 2^7^4 = 1
+        a[2] = 7;
+        ASSERT_EQ(st.make_query(0, 4).val, brute_xor(a, 0, 4));
+        ASSERT_EQ(st.make_query(2, 2).val, brute_xor(a, 2, 2));
+        ASSERT_EQ(st.make_query(1, 3).val, brute_xor(a, 1, 3));
     }
 
     // --- Single element array ---
     {
         vector<long long> a = {42};
         SegTree<Node1, Update1> st(1, a);
-        ASSERT_EQ(st.make_query(0, 0).val, 42LL);
+        ASSERT_EQ(st.make_query(0, 0).val, brute_xor(a, 0, 0));
         st.make_update(0, 99);
-        ASSERT_EQ(st.make_query(0, 0).val, 99LL);
+        a[0] = 99;
+        ASSERT_EQ(st.make_query(0, 0).val, brute_xor(a, 0, 0));
     }
 
     // --- Two element array ---
     {
         vector<long long> a = {5, 3};
         SegTree<Node1, Update1> st(2, a);
-        ASSERT_EQ(st.make_query(0, 1).val, 6LL);   // 5^3 = 6
-        ASSERT_EQ(st.make_query(0, 0).val, 5LL);
-        ASSERT_EQ(st.make_query(1, 1).val, 3LL);
+        ASSERT_EQ(st.make_query(0, 1).val, brute_xor(a, 0, 1));
+        ASSERT_EQ(st.make_query(0, 0).val, brute_xor(a, 0, 0));
+        ASSERT_EQ(st.make_query(1, 1).val, brute_xor(a, 1, 1));
         st.make_update(0, 3);
-        ASSERT_EQ(st.make_query(0, 1).val, 0LL);   // 3^3 = 0
+        a[0] = 3;
+        ASSERT_EQ(st.make_query(0, 1).val, brute_xor(a, 0, 1));
     }
 
     // --- All-same values ---
     {
         vector<long long> a(8, 7);
         SegTree<Node1, Update1> st(8, a);
-        ASSERT_EQ(st.make_query(0, 7).val, 0LL);   // 7^7^7^7^7^7^7^7 = 0 (even count)
-        ASSERT_EQ(st.make_query(0, 6).val, 7LL);   // odd count → 7
-        ASSERT_EQ(st.make_query(2, 4).val, 7LL);   // 7^7^7 = 7
+        ASSERT_EQ(st.make_query(0, 7).val, brute_xor(a, 0, 7));
+        ASSERT_EQ(st.make_query(0, 6).val, brute_xor(a, 0, 6));
+        ASSERT_EQ(st.make_query(2, 4).val, brute_xor(a, 2, 4));
     }
 
     // --- All zeros ---
     {
         vector<long long> a(6, 0);
         SegTree<Node1, Update1> st(6, a);
-        ASSERT_EQ(st.make_query(0, 5).val, 0LL);
+        ASSERT_EQ(st.make_query(0, 5).val, brute_xor(a, 0, 5));
         st.make_update(3, 15);
-        ASSERT_EQ(st.make_query(0, 5).val, 15LL);
-        ASSERT_EQ(st.make_query(3, 3).val, 15LL);
-        ASSERT_EQ(st.make_query(0, 2).val, 0LL);
+        a[3] = 15;
+        ASSERT_EQ(st.make_query(0, 5).val, brute_xor(a, 0, 5));
+        ASSERT_EQ(st.make_query(3, 3).val, brute_xor(a, 3, 3));
+        ASSERT_EQ(st.make_query(0, 2).val, brute_xor(a, 0, 2));
     }
 
     // --- Power-of-two size (n=8) ---
@@ -78,9 +82,23 @@ int run_tests() {
         ASSERT_EQ(st.make_query(0, 7).val, brute_xor(a, 0, 7));
     }
 
+    // --- Consecutive updates to same position ---
+    {
+        vector<long long> a = {10, 20, 30};
+        SegTree<Node1, Update1> st(3, a);
+        st.make_update(1, 5);
+        a[1] = 5;
+        ASSERT_EQ(st.make_query(1, 1).val, brute_xor(a, 1, 1));
+        st.make_update(1, 100);
+        a[1] = 100;
+        ASSERT_EQ(st.make_query(1, 1).val, brute_xor(a, 1, 1));
+        ASSERT_EQ(st.make_query(0, 2).val, brute_xor(a, 0, 2));
+    }
+
     // --- Stress test: n=300, random point updates and range XOR queries ---
     {
-        mt19937 rng(7);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         const int n = 300;
         vector<long long> a(n);
         for (int i = 0; i < n; i++) a[i] = rng() % 1000000;
@@ -89,43 +107,36 @@ int run_tests() {
 
         for (int iter = 0; iter < 600; iter++) {
             if (rng() % 2 == 0) {
-                // Random point update
                 int pos = rng() % n;
                 long long val = rng() % 1000000;
                 a[pos] = val;
                 st.make_update(pos, val);
             } else {
-                // Random range XOR query
                 int l = rng() % n;
                 int r = rng() % n;
                 if (l > r) swap(l, r);
+                long long got = st.make_query(l, r).val;
                 long long expected = brute_xor(a, l, r);
-                ASSERT_EQ(st.make_query(l, r).val, expected);
+                if (got != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
+                ASSERT_EQ(got, expected);
             }
         }
     }
 
     // --- Stress test: n=1 repeatedly updated ---
     {
-        mt19937 rng(13);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         vector<long long> a = {0};
         SegTree<Node1, Update1> st(1, a);
         for (int i = 0; i < 100; i++) {
             long long v = rng() % 100000;
             st.make_update(0, v);
-            ASSERT_EQ(st.make_query(0, 0).val, v);
+            a[0] = v;
+            long long got = st.make_query(0, 0).val;
+            if (got != a[0]) cerr << "Stress test failed (seed=" << seed << ")\n";
+            ASSERT_EQ(got, brute_xor(a, 0, 0));
         }
-    }
-
-    // --- Consecutive updates to same position ---
-    {
-        vector<long long> a = {10, 20, 30};
-        SegTree<Node1, Update1> st(3, a);
-        st.make_update(1, 5);
-        ASSERT_EQ(st.make_query(1, 1).val, 5LL);
-        st.make_update(1, 100);
-        ASSERT_EQ(st.make_query(1, 1).val, 100LL);
-        ASSERT_EQ(st.make_query(0, 2).val, (10LL ^ 100LL ^ 30LL));
     }
 
     TEST_PASS();

--- a/tests/test_sparse_table.cpp
+++ b/tests/test_sparse_table.cpp
@@ -1,0 +1,28 @@
+#include "common.h"
+#include "../Range Queries/Sparse_Table.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Array [3, 1, 4, 1, 5, 9, 2, 6], Node1 uses XOR merge
+    vector<long long> a = {3, 1, 4, 1, 5, 9, 2, 6};
+    SparseTable<Node1> sp(8, a);
+
+    // XOR of [0,2] = 3^1^4 = 6
+    ASSERT_EQ(sp.queryNormal(0, 2).val, 6LL);
+
+    // XOR of [0,0] = 3
+    ASSERT_EQ(sp.queryNormal(0, 0).val, 3LL);
+
+    // XOR of [2,5] = 4^1^5^9 = 9
+    // 4^1=5, 5^5=0, 0^9=9
+    ASSERT_EQ(sp.queryNormal(2, 5).val, 9LL);
+
+    // XOR of [5,7] = 9^2^6 = 13
+    // 9^2=11, 11^6=13
+    ASSERT_EQ(sp.queryNormal(5, 7).val, 13LL);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_sparse_table.cpp
+++ b/tests/test_sparse_table.cpp
@@ -29,10 +29,10 @@ int run_tests() {
         vector<long long> a = {3, 1, 4, 1, 5, 9, 2, 6};
         SparseTable<Node1> sp(8, a);
 
-        ASSERT_EQ(sp.queryNormal(0, 2).val, 6LL);   // 3^1^4 = 6
-        ASSERT_EQ(sp.queryNormal(0, 0).val, 3LL);
-        ASSERT_EQ(sp.queryNormal(2, 5).val, 9LL);   // 4^1^5^9 = 9
-        ASSERT_EQ(sp.queryNormal(5, 7).val, 13LL);  // 9^2^6 = 13
+        ASSERT_EQ(sp.queryNormal(0, 2).val, brute_xor(a, 0, 2));
+        ASSERT_EQ(sp.queryNormal(0, 0).val, brute_xor(a, 0, 0));
+        ASSERT_EQ(sp.queryNormal(2, 5).val, brute_xor(a, 2, 5));
+        ASSERT_EQ(sp.queryNormal(5, 7).val, brute_xor(a, 5, 7));
         ASSERT_EQ(sp.queryNormal(0, 7).val, brute_xor(a, 0, 7));
         ASSERT_EQ(sp.queryNormal(1, 6).val, brute_xor(a, 1, 6));
     }
@@ -41,25 +41,25 @@ int run_tests() {
     {
         vector<long long> a = {42};
         SparseTable<Node1> sp(1, a);
-        ASSERT_EQ(sp.queryNormal(0, 0).val, 42LL);
+        ASSERT_EQ(sp.queryNormal(0, 0).val, brute_xor(a, 0, 0));
     }
 
     // --- Two elements ---
     {
         vector<long long> a = {10, 7};
         SparseTable<Node1> sp(2, a);
-        ASSERT_EQ(sp.queryNormal(0, 0).val, 10LL);
-        ASSERT_EQ(sp.queryNormal(1, 1).val, 7LL);
-        ASSERT_EQ(sp.queryNormal(0, 1).val, 13LL);  // 10^7
+        ASSERT_EQ(sp.queryNormal(0, 0).val, brute_xor(a, 0, 0));
+        ASSERT_EQ(sp.queryNormal(1, 1).val, brute_xor(a, 1, 1));
+        ASSERT_EQ(sp.queryNormal(0, 1).val, brute_xor(a, 0, 1));
     }
 
     // --- All same values (XOR) ---
     {
         vector<long long> a(8, 5);
         SparseTable<Node1> sp(8, a);
-        ASSERT_EQ(sp.queryNormal(0, 7).val, 0LL);  // even count → 0
-        ASSERT_EQ(sp.queryNormal(0, 6).val, 5LL);  // odd count → 5
-        ASSERT_EQ(sp.queryNormal(0, 0).val, 5LL);
+        ASSERT_EQ(sp.queryNormal(0, 7).val, brute_xor(a, 0, 7));  // even count → 0
+        ASSERT_EQ(sp.queryNormal(0, 6).val, brute_xor(a, 0, 6));  // odd count → 5
+        ASSERT_EQ(sp.queryNormal(0, 0).val, brute_xor(a, 0, 0));
     }
 
     // --- All zeros ---
@@ -68,7 +68,7 @@ int run_tests() {
         SparseTable<Node1> sp(5, a);
         for (int l = 0; l < 5; l++)
             for (int r = l; r < 5; r++)
-                ASSERT_EQ(sp.queryNormal(l, r).val, 0LL);
+                ASSERT_EQ(sp.queryNormal(l, r).val, brute_xor(a, l, r));
     }
 
     // --- Power-of-two size (n=16), exhaustive queryNormal ---
@@ -93,20 +93,21 @@ int run_tests() {
     {
         vector<long long> a(6, 3);
         SparseTable<NodeMin> sp(6, a);
-        ASSERT_EQ(sp.queryIdempotent(0, 5).val, 3LL);
-        ASSERT_EQ(sp.queryIdempotent(2, 4).val, 3LL);
+        ASSERT_EQ(sp.queryIdempotent(0, 5).val, brute_min(a, 0, 5));
+        ASSERT_EQ(sp.queryIdempotent(2, 4).val, brute_min(a, 2, 4));
     }
 
-    // --- Idempotent: min of single element ---
+    // --- Idempotent: single element ---
     {
         vector<long long> a = {99};
         SparseTable<NodeMin> sp(1, a);
-        ASSERT_EQ(sp.queryIdempotent(0, 0).val, 99LL);
+        ASSERT_EQ(sp.queryIdempotent(0, 0).val, brute_min(a, 0, 0));
     }
 
     // --- Stress test: n=500, random XOR range queries ---
     {
-        mt19937 rng(17);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         const int n = 500;
         vector<long long> a(n);
         for (int i = 0; i < n; i++) a[i] = rng() % 1000000;
@@ -116,13 +117,17 @@ int run_tests() {
             int l = rng() % n;
             int r = rng() % n;
             if (l > r) swap(l, r);
-            ASSERT_EQ(sp.queryNormal(l, r).val, brute_xor(a, l, r));
+            long long got = sp.queryNormal(l, r).val;
+            long long expected = brute_xor(a, l, r);
+            if (got != expected) cerr << "XOR stress test failed (seed=" << seed << ")\n";
+            ASSERT_EQ(got, expected);
         }
     }
 
     // --- Stress test: n=500, random min queries (idempotent) ---
     {
-        mt19937 rng(31);
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
         const int n = 500;
         vector<long long> a(n);
         for (int i = 0; i < n; i++) a[i] = (long long)(rng() % 1000000);
@@ -132,7 +137,10 @@ int run_tests() {
             int l = rng() % n;
             int r = rng() % n;
             if (l > r) swap(l, r);
-            ASSERT_EQ(sp.queryIdempotent(l, r).val, brute_min(a, l, r));
+            long long got = sp.queryIdempotent(l, r).val;
+            long long expected = brute_min(a, l, r);
+            if (got != expected) cerr << "Min stress test failed (seed=" << seed << ")\n";
+            ASSERT_EQ(got, expected);
         }
     }
 

--- a/tests/test_sparse_table.cpp
+++ b/tests/test_sparse_table.cpp
@@ -3,24 +3,138 @@
 
 using namespace std;
 
+long long brute_xor(vector<long long>& a, int l, int r) {
+    long long res = 0;
+    for (int i = l; i <= r; i++) res ^= a[i];
+    return res;
+}
+
+// Min node for idempotent queryIdempotent tests
+struct NodeMin {
+    long long val = LLONG_MAX;
+    NodeMin() = default;
+    NodeMin(long long v) : val(v) {}
+    void merge(const NodeMin& l, const NodeMin& r) { val = min(l.val, r.val); }
+};
+
+long long brute_min(vector<long long>& a, int l, int r) {
+    long long res = LLONG_MAX;
+    for (int i = l; i <= r; i++) res = min(res, a[i]);
+    return res;
+}
+
 int run_tests() {
-    // Array [3, 1, 4, 1, 5, 9, 2, 6], Node1 uses XOR merge
-    vector<long long> a = {3, 1, 4, 1, 5, 9, 2, 6};
-    SparseTable<Node1> sp(8, a);
+    // --- Small test: [3, 1, 4, 1, 5, 9, 2, 6], XOR (non-idempotent) ---
+    {
+        vector<long long> a = {3, 1, 4, 1, 5, 9, 2, 6};
+        SparseTable<Node1> sp(8, a);
 
-    // XOR of [0,2] = 3^1^4 = 6
-    ASSERT_EQ(sp.queryNormal(0, 2).val, 6LL);
+        ASSERT_EQ(sp.queryNormal(0, 2).val, 6LL);   // 3^1^4 = 6
+        ASSERT_EQ(sp.queryNormal(0, 0).val, 3LL);
+        ASSERT_EQ(sp.queryNormal(2, 5).val, 9LL);   // 4^1^5^9 = 9
+        ASSERT_EQ(sp.queryNormal(5, 7).val, 13LL);  // 9^2^6 = 13
+        ASSERT_EQ(sp.queryNormal(0, 7).val, brute_xor(a, 0, 7));
+        ASSERT_EQ(sp.queryNormal(1, 6).val, brute_xor(a, 1, 6));
+    }
 
-    // XOR of [0,0] = 3
-    ASSERT_EQ(sp.queryNormal(0, 0).val, 3LL);
+    // --- Single element ---
+    {
+        vector<long long> a = {42};
+        SparseTable<Node1> sp(1, a);
+        ASSERT_EQ(sp.queryNormal(0, 0).val, 42LL);
+    }
 
-    // XOR of [2,5] = 4^1^5^9 = 9
-    // 4^1=5, 5^5=0, 0^9=9
-    ASSERT_EQ(sp.queryNormal(2, 5).val, 9LL);
+    // --- Two elements ---
+    {
+        vector<long long> a = {10, 7};
+        SparseTable<Node1> sp(2, a);
+        ASSERT_EQ(sp.queryNormal(0, 0).val, 10LL);
+        ASSERT_EQ(sp.queryNormal(1, 1).val, 7LL);
+        ASSERT_EQ(sp.queryNormal(0, 1).val, 13LL);  // 10^7
+    }
 
-    // XOR of [5,7] = 9^2^6 = 13
-    // 9^2=11, 11^6=13
-    ASSERT_EQ(sp.queryNormal(5, 7).val, 13LL);
+    // --- All same values (XOR) ---
+    {
+        vector<long long> a(8, 5);
+        SparseTable<Node1> sp(8, a);
+        ASSERT_EQ(sp.queryNormal(0, 7).val, 0LL);  // even count → 0
+        ASSERT_EQ(sp.queryNormal(0, 6).val, 5LL);  // odd count → 5
+        ASSERT_EQ(sp.queryNormal(0, 0).val, 5LL);
+    }
+
+    // --- All zeros ---
+    {
+        vector<long long> a(5, 0);
+        SparseTable<Node1> sp(5, a);
+        for (int l = 0; l < 5; l++)
+            for (int r = l; r < 5; r++)
+                ASSERT_EQ(sp.queryNormal(l, r).val, 0LL);
+    }
+
+    // --- Power-of-two size (n=16), exhaustive queryNormal ---
+    {
+        vector<long long> a = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
+        SparseTable<Node1> sp(16, a);
+        for (int l = 0; l < 16; l++)
+            for (int r = l; r < 16; r++)
+                ASSERT_EQ(sp.queryNormal(l, r).val, brute_xor(a, l, r));
+    }
+
+    // --- Idempotent query (range min) ---
+    {
+        vector<long long> a = {5, 3, 8, 1, 9, 2, 7, 4};
+        SparseTable<NodeMin> sp(8, a);
+        for (int l = 0; l < 8; l++)
+            for (int r = l; r < 8; r++)
+                ASSERT_EQ(sp.queryIdempotent(l, r).val, brute_min(a, l, r));
+    }
+
+    // --- Idempotent: all same values ---
+    {
+        vector<long long> a(6, 3);
+        SparseTable<NodeMin> sp(6, a);
+        ASSERT_EQ(sp.queryIdempotent(0, 5).val, 3LL);
+        ASSERT_EQ(sp.queryIdempotent(2, 4).val, 3LL);
+    }
+
+    // --- Idempotent: min of single element ---
+    {
+        vector<long long> a = {99};
+        SparseTable<NodeMin> sp(1, a);
+        ASSERT_EQ(sp.queryIdempotent(0, 0).val, 99LL);
+    }
+
+    // --- Stress test: n=500, random XOR range queries ---
+    {
+        mt19937 rng(17);
+        const int n = 500;
+        vector<long long> a(n);
+        for (int i = 0; i < n; i++) a[i] = rng() % 1000000;
+        SparseTable<Node1> sp(n, a);
+
+        for (int iter = 0; iter < 1000; iter++) {
+            int l = rng() % n;
+            int r = rng() % n;
+            if (l > r) swap(l, r);
+            ASSERT_EQ(sp.queryNormal(l, r).val, brute_xor(a, l, r));
+        }
+    }
+
+    // --- Stress test: n=500, random min queries (idempotent) ---
+    {
+        mt19937 rng(31);
+        const int n = 500;
+        vector<long long> a(n);
+        for (int i = 0; i < n; i++) a[i] = (long long)(rng() % 1000000);
+        SparseTable<NodeMin> sp(n, a);
+
+        for (int iter = 0; iter < 1000; iter++) {
+            int l = rng() % n;
+            int r = rng() % n;
+            if (l > r) swap(l, r);
+            ASSERT_EQ(sp.queryIdempotent(l, r).val, brute_min(a, l, r));
+        }
+    }
 
     TEST_PASS();
 }


### PR DESCRIPTION
## Summary

Chains onto PR3. Contains **4 algorithm files**.

- **`Segment_tree.cpp`**: clean `SegTree<Node, Update>` template; remove old `arr` member and boilerplate
- **`Lazy_SGT.cpp`**: clean `LazySGT<Node, Update>` template with lazy propagation
- **`Sparse_Table.cpp`**: clean template; O(1) idempotent and O(log N) general queries
- **`Mo_algo.cpp`**: extract `moDistinctQueries()` from `main()`; Mo's block sort included

All: `#include <bits/stdc++.h>`, `using namespace std`, no `static` helpers.

**4 test files** — one per template.

## Test plan

- [ ] `make -C tests run` — 7 tests pass (3 from prior PRs + 4 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_