### PR TITLE
PR6: Refactor Tree Algorithms (5 files) + tests

### DIFF
--- a/Tree Algorithms/Binary_Lifting.cpp
+++ b/Tree Algorithms/Binary_Lifting.cpp
@@ -1,51 +1,37 @@
+// O(N log N) preprocessing, O(log N) per kth-ancestor query
+// Build BinaryLifting(n, edges, maxK, root) where maxK is the max k you'll query
+// kthParent(u, k) returns the k-th ancestor of u, or -1 if it doesn't exist
+#include <bits/stdc++.h>
+using namespace std;
+
 struct BinaryLifting {
-    int n;
-    int maxLog;
-    ll maxRequirement;
+    int n, maxLog;
     vector<vector<int>> parent;
-    BinaryLifting(int n1, vector<int> *edges, ll requirement, int root) {
-        n = n1;
-        parent.resize(n1);
-        maxLog = log2(requirement + 1);
-        maxRequirement = requirement;
-        for (int i = 0; i < n; i++) {
-            parent[i].resize(maxLog + 1);
-            for (int j = 0; j <= maxLog; j++) {
-                parent[i][j] = -1;
-            }
-        }
-        fillParentTable(root, edges);
+
+    BinaryLifting(int n, vector<int>* edges, long long maxK, int root)
+        : n(n), maxLog((int)log2(maxK + 1) + 1), parent(n, vector<int>((int)log2(maxK + 1) + 2, -1)) {
+        _dfs(root, -1, edges);
+        for (int j = 1; j <= maxLog; j++)
+            for (int u = 0; u < n; u++)
+                if (parent[u][j - 1] != -1)
+                    parent[u][j] = parent[parent[u][j - 1]][j - 1];
     }
-    void fillParentTable(int root, vector<int> *edges) {
-        vector<bool> visited(n);
-        dfsBinaryLifting(root, edges, visited);
-        int intermediate = -1;
-        for (int i = 1; i <= maxLog; i++) {
-            for (int j = 0; j < n; j++) {
-                intermediate = parent[j][i - 1];
-                if (intermediate != -1) {
-                    parent[j][i] = parent[intermediate][i - 1];
-                }
-            }
-        }
+
+    void _dfs(int u, int par, vector<int>* edges) {
+        parent[u][0] = par;
+        for (int v : edges[u])
+            if (v != par)
+                _dfs(v, u, edges);
     }
-    void dfsBinaryLifting(int root, vector<int> *edges, vector<bool> &visited) {
-        visited[root] = true;
-        for (auto i : edges[root]) {
-            if (!visited[i]) {
-                parent[i][0] = root;
-                dfsBinaryLifting(i, edges, visited);
+
+    int kthParent(int u, int k) {
+        for (int j = maxLog; j >= 0; j--) {
+            if (k >= (1 << j)) {
+                u = parent[u][j];
+                k -= (1 << j);
+                if (u == -1) return -1;
             }
         }
-    }
-    int kthParent(int x, int k) {
-        for(int i = 0; i <= maxLog; i++){
-            if((k >> i) & 1){ 
-                if(x == -1)
-                    return x;
-                x = parent[x][i];
-            }
-        }
-        return x;
+        return u;
     }
 };

--- a/Tree Algorithms/Centroid_Tree.cpp
+++ b/Tree Algorithms/Centroid_Tree.cpp
@@ -1,63 +1,51 @@
+// O(N log N) — Centroid Decomposition
+// Edges stored as index pairs in edgeList; edges[u] holds edge indices.
+// Call decompose(root, edges, centroidTree, -1) to build centroid tree.
+// centroidTree[u] = neighbours of u in the centroid decomposition tree.
+// Returns the centroid of the initial component.
+#include <bits/stdc++.h>
+using namespace std;
+
 vector<pair<int, int>> edgeList;
 vector<bool> deleted;
 vector<int> subtree;
-inline int getD(int index, int s){
-    return edgeList[index].ff ^ edgeList[index].ss ^ s;
+
+int _getOther(int edgeIdx, int u) {
+    return edgeList[edgeIdx].first ^ edgeList[edgeIdx].second ^ u;
 }
-void computeSubtrees(int root, vector<int>* edges, int parent){
-    subtree[root] = 1;
-    for(auto i : edges[root]){
-        int dest = getD(i, root);
-        if(!deleted[i] && dest != parent){
-            computeSubtrees(dest, edges, root);
-            subtree[root] += subtree[dest];
+
+void _computeSubtrees(int u, vector<int>* edges, int parent) {
+    subtree[u] = 1;
+    for (int i : edges[u]) {
+        int v = _getOther(i, u);
+        if (!deleted[i] && v != parent) {
+            _computeSubtrees(v, edges, u);
+            subtree[u] += subtree[v];
         }
     }
 }
-int findCentroid(int root, vector<int>* edges, int n, int parent){
-    for(auto i : edges[root]){
-        int dest = getD(i, root);
-        if(!deleted[i] && dest != parent && subtree[dest] > n / 2){
-            return findCentroid(dest, edges, n, root);
-        }
+
+int _findCentroid(int u, vector<int>* edges, int treeSize, int parent) {
+    for (int i : edges[u]) {
+        int v = _getOther(i, u);
+        if (!deleted[i] && v != parent && subtree[v] > treeSize / 2)
+            return _findCentroid(v, edges, treeSize, u);
     }
-    return root;
+    return u;
 }
-int decompose(int root, vector<int>* edges, vector<int>* edgesN, int parent){
-    computeSubtrees(root, edges, -1);
+
+int decompose(int root, vector<int>* edges, vector<int>* centroidTree, int parent) {
+    _computeSubtrees(root, edges, -1);
     int n = subtree[root];
-    root = findCentroid(root, edges, n, -1);
-    if(parent != -1){
-        edgesN[root].pb(parent);
-        edgesN[parent].pb(root);
+    root = _findCentroid(root, edges, n, -1);
+    if (parent != -1) {
+        centroidTree[root].push_back(parent);
+        centroidTree[parent].push_back(root);
     }
-    for(auto i : edges[root]){
-        int dest = getD(i, root);
-        if(deleted[i])
-            continue;
+    for (int i : edges[root]) {
+        if (deleted[i]) continue;
         deleted[i] = true;
-        decompose(dest, edges, edgesN, root);
+        decompose(_getOther(i, root), edges, centroidTree, root);
     }
     return root;
-}
-void solve() {
-    int n;
-    cin >> n;
-    edgeList.clear();
-    deleted.clear();
-    vector<int>* edges= new vector<int>[n];
-    for(int i = 0; i < n - 1; i++){
-        int a, b;
-        cin >> a >> b;
-        a--, b--;
-        edges[a].pb(sz(edgeList));
-        edges[b].pb(sz(edgeList));
-        edgeList.pb({a, b});
-        deleted.pb(0);
-    }
-    vector<int>* edgesN = new vector<int>[n];
-    subtree.resize(n);
-    fill(all(subtree), 0);
-    int root = 0;
-    root = decompose(root, edges, edgesN, -1);
 }

--- a/Tree Algorithms/HLD.cpp
+++ b/Tree Algorithms/HLD.cpp
@@ -1,323 +1,199 @@
+// Heavy-Light Decomposition — path queries/updates in O(log²N)
+// Usage:
+//   BinaryLifting bl(n, edges, n, root);
+//   LCA lca(n, edges, root, &bl);
+//   HLD<Node1, Update1> hld(n, edges, root, nodeValues, &lca);
+//   hld.findAnswer(u, v)       — query over path u→v
+//   hld.makeUpdateatIndex(u, val) — point update at node u
+// Customise Node1 and Update1 for your query type (example: range-max below).
+#include <bits/stdc++.h>
+using namespace std;
 
-// No need to change anything here
+// ── Binary Lifting ────────────────────────────────────────────────────────────
 struct BinaryLifting {
-	int n;
-	int maxLog;
-	ll maxRequirement;
-	vector<vector<int>> parent;
-	vector<int> *edges;
-	vector<int> logValues;
-	bool precomputedLogs = false;
-	BinaryLifting(int n1, vector<int> *edges1, ll requirement, int root) {
-		n = n1;
-		edges = edges1;
-		parent.resize(n);
-		maxLog = log2(requirement + 1);
-		maxRequirement = requirement;
-		for (int i = 0; i < n; i++) {
-			parent[i].resize(maxLog + 1);
-			for (int j = 0; j <= maxLog; j++) {
-				parent[i][j] = -1;
-			}
-		}
-		fillParentTable(root);
-		if (maxRequirement <= 1000000LL)
-			precomputeLogs();
-	}
-	BinaryLifting() {}
-	void fillParentTable(int root) {
-		vector<bool> visited(n);
-		dfsBinaryLifting(root, visited);
-		int intermediate = -1;
-		for (int i = 1; i <= maxLog; i++) {
-			for (int j = 0; j < n; j++) {
-				intermediate = parent[j][i - 1];
-				if (intermediate != -1) {
-					parent[j][i] = parent[intermediate][i - 1];
-				}
-			}
-		}
-	}
-	void dfsBinaryLifting(int root, vector<bool> &visited) {
-		visited[root] = true;
-		for (auto i : edges[root]) {
-			if (!visited[i]) {
-				parent[i][0] = root;
-				dfsBinaryLifting(i, visited);
-			}
-		}
-	}
-	void precomputeLogs() {
-		precomputedLogs = true;
-		logValues.resize(maxRequirement + 1);
-		logValues[1] = 0;
-		for (int i = 2; i <= maxRequirement; i++) {
-			logValues[i] = logValues[i / 2] + 1;
-		}
-	}
-	int kthParent(int start, int k) {
-		int a = start;
-		while (k > 0) {
-			int x = getLog(k);
-			a = parent[a][x];
-			if (a == -1)
-				return a;
-			k -= (1 << x);
-		}
-		return a;
-	}
-	int getLog(ll x) {
-		return precomputedLogs ? logValues[x] : log2(x);
-	}
+    int n, maxLog;
+    vector<int>* edges;
+    vector<vector<int>> parent;
+
+    BinaryLifting(int n, vector<int>* edges, long long maxK, int root)
+        : n(n), edges(edges), maxLog((int)log2(maxK + 1) + 1),
+          parent(n, vector<int>((int)log2(maxK + 1) + 2, -1)) {
+        vector<bool> vis(n, false);
+        _dfs(root, vis);
+        for (int j = 1; j <= maxLog; j++)
+            for (int u = 0; u < n; u++)
+                if (parent[u][j - 1] != -1)
+                    parent[u][j] = parent[parent[u][j - 1]][j - 1];
+    }
+    BinaryLifting() : n(0), maxLog(0), edges(nullptr) {}
+
+    void _dfs(int u, vector<bool>& vis) {
+        vis[u] = true;
+        for (int v : edges[u])
+            if (!vis[v]) { parent[v][0] = u; _dfs(v, vis); }
+    }
+
+    int kthParent(int u, int k) {
+        for (int j = maxLog; j >= 0; j--)
+            if (k >= (1 << j)) { u = parent[u][j]; k -= (1 << j); if (u == -1) return -1; }
+        return u;
+    }
 };
 
-// No need to change anything here
+// ── LCA ───────────────────────────────────────────────────────────────────────
 struct LCA {
-	int n;
-	BinaryLifting *bl_object;
-	vector<int> level;
-	vector<int> *edges;
-	LCA(int n1, vector<int> *edges1, int root, BinaryLifting *bl) {
-		n = n1;
-		bl_object = bl;
-		edges = edges1;
-		level.resize(n);
-		dfsLCA(root, -1);
-	}
-	LCA() {}
-	void dfsLCA(int root, int parent) {
-		for (auto i : edges[root]) {
-			if (i != parent) {
-				level[i] = level[root] + 1;
-				dfsLCA(i, root);
-			}
-		}
-	}
-	int getLCA(int a, int b) {
-		if (level[a] > level[b]) {
-			swap(a, b);
-		}
-		b = bl_object->kthParent(b, level[b] - level[a]);
-		if (a == b)
-			return a;
-		for (int i = bl_object->maxLog; i >= 0; i--) {
-			int parent1 = bl_object->parent[a][i];
-			int parent2 = bl_object->parent[b][i];
-			if (parent2 != parent1 && parent1 != -1 && parent2 != -1) {
-				a = parent1;
-				b = parent2;
-			}
-		}
-		return bl_object->parent[a][0];
-	}
+    int n;
+    BinaryLifting* bl;
+    vector<int>* edges;
+    vector<int> level;
+
+    LCA(int n, vector<int>* edges, int root, BinaryLifting* bl)
+        : n(n), bl(bl), edges(edges), level(n, 0) {
+        _dfs(root, -1);
+    }
+    LCA() : n(0), bl(nullptr), edges(nullptr) {}
+
+    void _dfs(int u, int par) {
+        for (int v : edges[u])
+            if (v != par) { level[v] = level[u] + 1; _dfs(v, u); }
+    }
+
+    int getLCA(int a, int b) {
+        if (level[a] < level[b]) swap(a, b);
+        a = bl->kthParent(a, level[a] - level[b]);
+        if (a == b) return a;
+        for (int j = bl->maxLog; j >= 0; j--)
+            if (bl->parent[a][j] != bl->parent[b][j]) {
+                a = bl->parent[a][j]; b = bl->parent[b][j];
+            }
+        return bl->parent[a][0];
+    }
 };
 
-
+// ── Segment Tree (point update, range query) ──────────────────────────────────
 template<typename Node, typename Update>
 struct SegTree {
-	vector<Node> tree;
-	vector<ll> arr; // type may change
-	int n;
-	SegTree(int a_len, vector<ll> &a) { // change if type updated
-		arr = a;
-		n = a_len;
-		tree.resize(4 * n); fill(all(tree), Node());
-		build(0, n - 1, 1);
-	}
-	SegTree() {}
-	void build(int start, int end, int index)  // Never change this
-	{
-		if (start == end)	{
-			tree[index] = Node(arr[start]);
-			return;
-		}
-		int mid = (start + end) / 2;
-		build(start, mid, 2 * index);
-		build(mid + 1, end, 2 * index + 1);
-		tree[index].merge(tree[2 * index], tree[2 * index + 1]);
-	}
-	void update(int start, int end, int index, int query_index, Update &u)  // Never Change this
-	{
-		if (start == end) {
-			u.apply(tree[index]);
-			return;
-		}
-		int mid = (start + end) / 2;
-		if (mid >= query_index)
-			update(start, mid, 2 * index, query_index, u);
-		else
-			update(mid + 1, end, 2 * index + 1, query_index, u);
-		tree[index].merge(tree[2 * index], tree[2 * index + 1]);
-	}
-	Node query(int start, int end, int index, int left, int right) { // Never change this
-		if (start > right || end < left)
-			return Node();
-		if (start >= left && end <= right)
-			return tree[index];
-		int mid = (start + end) / 2;
-		Node l, r, ans;
-		l = query(start, mid, 2 * index, left, right);
-		r = query(mid + 1, end, 2 * index + 1, left, right);
-		ans.merge(l, r);
-		return ans;
-	}
-	void make_update(int index, ll val) {  // pass in as many parameters as required
-		Update new_update = Update(val); // may change
-		update(0, n - 1, 1, index, new_update);
-	}
-	Node make_query(int left, int right) {
-		return query(0, n - 1, 1, left, right);
-	}
+    vector<Node> tree;
+    int n, s;
+
+    SegTree(int n, vector<long long>& a) : n(n), s(1) {
+        while (s < 2 * n) s <<= 1;
+        tree.resize(s, Node());
+        _build(a, 0, n - 1, 1);
+    }
+    SegTree() : n(0), s(0) {}
+
+    void _build(vector<long long>& a, int l, int r, int idx) {
+        if (l == r) { tree[idx] = Node(a[l]); return; }
+        int m = (l + r) / 2;
+        _build(a, l, m, 2 * idx);
+        _build(a, m + 1, r, 2 * idx + 1);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
+    }
+
+    void _update(int l, int r, int idx, int pos, Update& u) {
+        if (l == r) { u.apply(tree[idx]); return; }
+        int m = (l + r) / 2;
+        if (pos <= m) _update(l, m, 2 * idx, pos, u);
+        else _update(m + 1, r, 2 * idx + 1, pos, u);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
+    }
+
+    Node _query(int l, int r, int idx, int ql, int qr) {
+        if (l > qr || r < ql) return Node();
+        if (l >= ql && r <= qr) return tree[idx];
+        int m = (l + r) / 2;
+        Node left, right, ans;
+        left = _query(l, m, 2 * idx, ql, qr);
+        right = _query(m + 1, r, 2 * idx + 1, ql, qr);
+        ans.merge(left, right);
+        return ans;
+    }
+
+    void make_update(int pos, long long val) { Update u(val); _update(0, n - 1, 1, pos, u); }
+    Node make_query(int l, int r) { return _query(0, n - 1, 1, l, r); }
 };
 
+// ── Example Node/Update: range-max with point set ─────────────────────────────
 struct Node1 {
-	ll val; // may change
-	Node1() { // Identity element
-		val = -INF;	// may change
-	}
-	Node1(ll p1) {  // Actual Node
-		val = p1; // may change
-	}
-	void merge(Node1 &l, Node1 &r) { // Merge two child nodes
-		val = max(l.val, r.val);  // may change
-	}
+    long long val;
+    Node1() : val(LLONG_MIN / 2) {}
+    Node1(long long v) : val(v) {}
+    void merge(const Node1& l, const Node1& r) { val = max(l.val, r.val); }
+};
+struct Update1 {
+    long long val;
+    Update1(long long v) : val(v) {}
+    void apply(Node1& a) { a.val = val; }
 };
 
-struct Update1 {
-	ll val; // may change
-	Update1(ll p1) { // Actual Update
-		val = p1; // may change
-	}
-	void apply(Node1 &a) { // apply update to given node
-		a.val = val; // may change
-	}
-};
+// ── HLD ───────────────────────────────────────────────────────────────────────
 template<typename Node, typename Update>
 struct HLD {
-	int n;
-	int rootHere;
-	vector<int> *edges;
-	vector<int> big_child;
-	vector<int> subtree_sum;
-	vector<int> chain;
-	vector<int> label;
-	vector<ll> values;
-	SegTree<Node, Update> s1;
-	LCA *lca_object;
-	BinaryLifting *bl_object;
-	HLD(int n1, vector<int> *edges1, int root1, vector<ll> &values1, LCA *lca) {
-		n = n1;
-		lca_object = lca;
-		bl_object = lca->bl_object;
-		edges = edges1;
-		rootHere = root1;
-		big_child.resize(n);
-		subtree_sum.resize(n);
-		label.resize(n);
-		chain.resize(n);
-		values = values1;
-		dfsPrecompute(rootHere, -1);
-		int label_time = 0;
-		dfsLabels(rootHere, -1, label_time);
-		for (int i = 0; i < n; i++)
-			chain[i] = i;
-		dfsChains(rootHere, -1);
-		s1 = SegTree<Node, Update>(n, values);
-		for (int i = 0; i < n; i++) {
-			s1.make_update(label[i], values[i]);
-		}
-		// debugHLD();
-	}
-	void dfsPrecompute(int root, int parent) {
-		subtree_sum[root] = 1;
-		big_child[root] = -1;
-		int biggest = -1;
-		for (auto i : edges[root]) {
-			if (i != parent) {
-				dfsPrecompute(i, root);
-				subtree_sum[root] += subtree_sum[i];
-				if (subtree_sum[i] > biggest) {
-					big_child[root] = i;
-					biggest = subtree_sum[i];
-				}
-			}
-		}
-	}
-	void dfsLabels(int root, int parent, int &label_time) {
-		label[root] = label_time++;
-		if (big_child[root] != -1)
-			dfsLabels(big_child[root], root, label_time);
-		for (auto i : edges[root])
-			if (i != parent && i != big_child[root])
-				dfsLabels(i, root, label_time);
-	}
-	void dfsChains(int root, int parent) {
-		if (big_child[root] != -1)
-			chain[big_child[root]] = chain[root];
-		for (auto i : edges[root])
-			if (i != parent)
-				dfsChains(i, root);
-	}
-	void debugHLD() {
-		debug(big_child);
-		debug(subtree_sum);
-		debug(chain);
-		debug(label);
-		debug(values);
-	}
-	Node queryChain(int here, int toReach) {
-		Node val = Node(0);
-		int top;
-		while (lca_object->level[here] > lca_object->level[toReach]) {
-			top = chain[here];
-			if (lca_object->level[top] <= lca_object->level[toReach])
-				top = bl_object->kthParent(here, lca_object->level[here] - lca_object->level[toReach] - 1);
-			Node a1 = val;
-			Node a2 = s1.make_query(label[top], label[here]);
-			val.merge(a1, a2);
-			here = bl_object->parent[top][0];
-		}
-		return val;
-	}
-	ll findAnswer(int u, int v) {
-		int lca = lca_object->getLCA(u, v);
-		Node n1 = queryChain(u, lca);
-		Node n2 = queryChain(v, lca);
-		Node merged;
-		merged.merge(n1, n2);
-		Node n3 = Node(s1.make_query(label[lca], label[lca]));
-		Node ans;
-		ans.merge(merged, n3);
-		return ans.val;
-	}
-	void makeUpdateatIndex(int u, ll val) {
-		s1.make_update(label[u], val);
-	}
+    int n, root;
+    vector<int>* edges;
+    vector<int> bigChild, subtreeSize, chainHead, label;
+    vector<long long> values;
+    SegTree<Node, Update> seg;
+    LCA* lca;
+    BinaryLifting* bl;
+
+    HLD(int n, vector<int>* edges, int root, vector<long long>& vals, LCA* lca)
+        : n(n), root(root), edges(edges), bigChild(n, -1), subtreeSize(n),
+          chainHead(n), label(n), values(vals), lca(lca), bl(lca->bl) {
+        _precompute(root, -1);
+        int t = 0;
+        _labelDfs(root, -1, t);
+        for (int i = 0; i < n; i++) chainHead[i] = i;
+        _chainDfs(root, -1);
+        seg = SegTree<Node, Update>(n, values);
+        for (int i = 0; i < n; i++) seg.make_update(label[i], values[i]);
+    }
+
+    void _precompute(int u, int par) {
+        subtreeSize[u] = 1; bigChild[u] = -1;
+        int best = -1;
+        for (int v : edges[u]) if (v != par) {
+            _precompute(v, u);
+            subtreeSize[u] += subtreeSize[v];
+            if (subtreeSize[v] > best) { best = subtreeSize[v]; bigChild[u] = v; }
+        }
+    }
+
+    void _labelDfs(int u, int par, int& t) {
+        label[u] = t++;
+        if (bigChild[u] != -1) _labelDfs(bigChild[u], u, t);
+        for (int v : edges[u]) if (v != par && v != bigChild[u]) _labelDfs(v, u, t);
+    }
+
+    void _chainDfs(int u, int par) {
+        if (bigChild[u] != -1) chainHead[bigChild[u]] = chainHead[u];
+        for (int v : edges[u]) if (v != par) _chainDfs(v, u);
+    }
+
+    Node _queryChain(int u, int ancestor) {
+        Node res;
+        while (lca->level[u] > lca->level[ancestor]) {
+            int top = chainHead[u];
+            if (lca->level[top] <= lca->level[ancestor])
+                top = bl->kthParent(u, lca->level[u] - lca->level[ancestor] - 1);
+            Node a = res, b = seg.make_query(label[top], label[u]);
+            res.merge(a, b);
+            u = bl->parent[top][0];
+        }
+        return res;
+    }
+
+    long long findAnswer(int u, int v) {
+        int anc = lca->getLCA(u, v);
+        Node a = _queryChain(u, anc);
+        Node b = _queryChain(v, anc);
+        Node c = seg.make_query(label[anc], label[anc]);
+        Node ab, ans;
+        ab.merge(a, b);
+        ans.merge(ab, c);
+        return ans.val;
+    }
+
+    void makeUpdateatIndex(int u, long long val) { seg.make_update(label[u], val); }
 };
-// Change accordingly for edge weights instead of node values
-void solve() {
-	int n, q;
-	cin >> n >> q;
-	vector<ll> values(n);
-	for (int i = 0; i < n; i++)
-		cin >> values[i];
-	vector<int> *edges = new vector<int>[n];
-	for (int i = 0; i < n - 1; i++) {
-		int a, b;
-		cin >> a >> b;
-		edges[a - 1].pb(b - 1);
-		edges[b - 1].pb(a - 1);
-	}
-	BinaryLifting bl_object = BinaryLifting(n, edges, n, 0);
-	LCA lca_object = LCA(n, edges, 0, &bl_object);
-	HLD<Node1, Update1> hld = HLD<Node1, Update1>(n, edges, 0, values, &lca_object);
-	while (q--) {
-		int a, b, c;
-		cin >> a >> b >> c;
-		if (a == 1) {
-			hld.makeUpdateatIndex(b - 1, c);
-		} else {
-			cout << hld.findAnswer(b - 1, c - 1) << " ";
-		}
-	}
-}

--- a/Tree Algorithms/LCA_O_1.cpp
+++ b/Tree Algorithms/LCA_O_1.cpp
@@ -1,102 +1,72 @@
+// O(N log N) preprocessing, O(1) per LCA query — via Euler tour + Sparse Table
+// Build LCA_O_1(n, edges, root), then call query(u, v). getDepth(u) returns depth.
+#include <bits/stdc++.h>
+using namespace std;
+
 template<typename Node>
 struct SparseTable {
     vector<vector<Node>> table;
-    vector<int> logValues;
-    int n;
-    int maxLog;
-    vector<int> a;
-    SparseTable(int n1, vector<int> &arr) {
-        n = n1;
-        a = arr;
-        table.resize(n);
-        logValues.resize(n + 1);
-        maxLog = log2(n);
-        logValues[1] = 0;
-        for (int i = 2; i <= n; i++) {
-            logValues[i] = logValues[i / 2] + 1;
-        }
-        for (int i = 0; i < n; i++) {
-            table[i].resize(maxLog + 1);
-            fill(all(table[i]), Node());
-        }
-        build();
+    vector<int> logVal;
+    int n, maxLog;
+
+    SparseTable(int n, vector<int>& arr) : n(n), logVal(n + 1, 0) {
+        maxLog = n > 1 ? (int)log2(n) : 0;
+        logVal[1] = 0;
+        for (int i = 2; i <= n; i++) logVal[i] = logVal[i / 2] + 1;
+        table.assign(n, vector<Node>(maxLog + 1, Node()));
+        for (int i = 0; i < n; i++) table[i][0] = Node(arr[i], i);
+        for (int j = 1; j <= maxLog; j++)
+            for (int i = 0; i + (1 << j) <= n; i++)
+                table[i][j].merge(table[i][j - 1], table[i + (1 << (j - 1))][j - 1]);
     }
-    void build() {
-        for (int i = 0; i < n; i++) {
-            table[i][0] = Node(a[i], i);
-        }
-        for (int i = 1; i <= maxLog; i++) {
-            for (int j = 0; (j + (1 << i)) <= n; j++) {
-                table[j][i].merge(table[j][i - 1], table[j + (1 << (i - 1))][i - 1]);
-            }
-        }
-    }
-    Node queryNormal(int left, int right) {
-        Node ans = Node();
-        for (int j = logValues[right - left + 1]; j >= 0; j--) {
-            if ((1 << j) <= right - left + 1) {
-                ans.merge(ans, table[left][j]);
-                left += (1 << j);
-            }
-        }
-        return ans;
-    }
-    Node queryIdempotent(int left, int right) {
-        int j = logValues[right - left + 1];
-        Node ans = Node();
-        ans.merge(table[left][j], table[right - (1 << j) + 1][j]);
+
+    Node queryIdempotent(int l, int r) {
+        int j = logVal[r - l + 1];
+        Node ans;
+        ans.merge(table[l][j], table[r - (1 << j) + 1][j]);
         return ans;
     }
 };
-struct Node1 {
-    int val; // store more info if required
-    int index;
-    Node1() { // Identity Element
-        val = 1e9;
-        index = -1;
-    }
-    Node1(int v, int ind) {
-        val = v;
-        index = ind;
-    }
-    void merge(Node1 &l, Node1 &r) {
-        if(l.val < r.val){
-            val = l.val;
-            index = l.index;
-        }else{
-            val = r.val;
-            index = r.index;
-        }
+
+struct MinNode {
+    int val = 1e9, idx = -1;
+    MinNode() = default;
+    MinNode(int v, int i) : val(v), idx(i) {}
+    void merge(const MinNode& l, const MinNode& r) {
+        if (l.val <= r.val) { val = l.val; idx = l.idx; }
+        else { val = r.val; idx = r.idx; }
     }
 };
-struct LCA_O_1{
+
+struct LCA_O_1 {
     int n;
-    vector<int> eulerTour, index;
-    vector<int> node;
-    SparseTable<Node1> sp = SparseTable<Node1>(0, eulerTour);
-    LCA_O_1(int n1, vector<int>* edges, int root){
-        n = n1;
-        index.resize(n);
-        dfs(root, edges, -1, 0);
-        sp = SparseTable<Node1>(sz(eulerTour), eulerTour);
-        debug(sz(eulerTour))
+    vector<int> eulerDepth, nodeAt, firstOccurrence;
+    SparseTable<MinNode> sp;
+
+    LCA_O_1(int n, vector<int>* edges, int root)
+        : n(n), firstOccurrence(n), sp(0, eulerDepth) {
+        _dfs(root, -1, edges, 0);
+        sp = SparseTable<MinNode>((int)eulerDepth.size(), eulerDepth);
     }
-    void dfs(int root, vector<int>* edges, int parent, int height){
-        eulerTour.pb(height);
-        node.pb(root);
-        index[root] = sz(eulerTour) - 1;
-        for(auto i : edges[root]){
-            if(i != parent){
-                dfs(i, edges, root, height + 1);
-                eulerTour.pb(height);
-                node.pb(root);
+
+    void _dfs(int u, int par, vector<int>* edges, int depth) {
+        firstOccurrence[u] = (int)eulerDepth.size();
+        eulerDepth.push_back(depth);
+        nodeAt.push_back(u);
+        for (int v : edges[u]) {
+            if (v != par) {
+                _dfs(v, u, edges, depth + 1);
+                eulerDepth.push_back(depth);
+                nodeAt.push_back(u);
             }
         }
     }
-    inline int query(int a, int b){
-        return node[sp.queryIdempotent(min(index[a], index[b]), max(index[a], index[b])).index];
+
+    int query(int u, int v) {
+        int l = min(firstOccurrence[u], firstOccurrence[v]);
+        int r = max(firstOccurrence[u], firstOccurrence[v]);
+        return nodeAt[sp.queryIdempotent(l, r).idx];
     }
-    inline int getDepth(int a){
-        return eulerTour[index[a]];
-    }
+
+    int getDepth(int u) { return eulerDepth[firstOccurrence[u]]; }
 };

--- a/Tree Algorithms/LCA_tree.cpp
+++ b/Tree Algorithms/LCA_tree.cpp
@@ -1,102 +1,68 @@
+// O(N log N) preprocessing, O(log N) per LCA query — via Binary Lifting
+// Build BinaryLifting first, then LCA. Call lca.getLCA(u, v).
+#include <bits/stdc++.h>
+using namespace std;
+
 struct BinaryLifting {
-	int n;
-	int maxLog;
-	ll maxRequirement;
-	vector<vector<int>> parent;
-	vector<int> logValues;
-	bool precomputedLogs = false;
-	BinaryLifting(int n1, vector<int> *edges, ll requirement, int root) {
-		n = n1;
-		parent.resize(n);
-		maxLog = log2(requirement + 1);
-		maxRequirement = requirement;
-		for (int i = 0; i < n; i++) {
-			parent[i].resize(maxLog + 1);
-			for (int j = 0; j <= maxLog; j++) {
-				parent[i][j] = -1;
-			}
-		}
-		fillParentTable(root, edges);
-		if (maxRequirement <= 1000000LL)
-			precomputeLogs();
-	}
-	void fillParentTable(int root, vector<int> *edges) {
-		vector<bool> visited(n);
-		dfsBinaryLifting(root, edges, visited);
-		int intermediate = -1;
-		for (int i = 1; i <= maxLog; i++) {
-			for (int j = 0; j < n; j++) {
-				intermediate = parent[j][i - 1];
-				if (intermediate != -1) {
-					parent[j][i] = parent[intermediate][i - 1];
-				}
-			}
-		}
-	}
-	void dfsBinaryLifting(int root, vector<int> *edges, vector<bool> &visited) {
-		visited[root] = true;
-		for (auto i : edges[root]) {
-			if (!visited[i]) {
-				parent[i][0] = root;
-				dfsBinaryLifting(i, edges, visited);
-			}
-		}
-	}
-	void precomputeLogs() {
-		precomputedLogs = true;
-		logValues.resize(maxRequirement + 1);
-		logValues[1] = 0;
-		for (int i = 2; i <= maxRequirement; i++) {
-			logValues[i] = logValues[i / 2] + 1;
-		}
-	}
-	int kthParent(int start, int k) {
-		int a = start;
-		while (k > 0) {
-			int x = getLog(k);
-			a = parent[a][x];
-			if (a == -1)
-				return a;
-			k -= (1 << x);
-		}
-		return a;
-	}
-	inline int getLog(ll x) {
-		return precomputedLogs ? logValues[x] : log2(x);
-	}
+    int n, maxLog;
+    vector<vector<int>> parent;
+
+    BinaryLifting(int n, vector<int>* edges, long long maxK, int root)
+        : n(n), maxLog((int)log2(maxK + 1) + 1),
+          parent(n, vector<int>((int)log2(maxK + 1) + 2, -1)) {
+        _dfs(root, -1, edges);
+        for (int j = 1; j <= maxLog; j++)
+            for (int u = 0; u < n; u++)
+                if (parent[u][j - 1] != -1)
+                    parent[u][j] = parent[parent[u][j - 1]][j - 1];
+    }
+
+    void _dfs(int u, int par, vector<int>* edges) {
+        parent[u][0] = par;
+        for (int v : edges[u])
+            if (v != par)
+                _dfs(v, u, edges);
+    }
+
+    int kthParent(int u, int k) {
+        for (int j = maxLog; j >= 0; j--) {
+            if (k >= (1 << j)) {
+                u = parent[u][j];
+                k -= (1 << j);
+                if (u == -1) return -1;
+            }
+        }
+        return u;
+    }
 };
 
 struct LCA {
-	int n;
-	vector<int> level;
-	LCA(int n1, vector<int> *edges, int root) {
-		n = n1;
-		level.resize(n);
-		dfsLCA(root, edges, -1);
-	}
-	void dfsLCA(int root, vector<int> *edges, int parent) {
-		for (auto i : edges[root]) {
-			if (i != parent) {
-				level[i] = level[root] + 1;
-				dfsLCA(i, edges, root);
-			}
-		}
-	}
-	int getLCA(int a, int b, BinaryLifting &bl_object) {
-		if (level[a] > level[b]) {
-			swap(a, b);
-		}
-		b = bl_object.kthParent(b, level[b] - level[a]);
-		if (a == b)
-			return a;
-		for (int i = bl_object.maxLog; i >= 0; i--) {
-			int parent1 = bl_object.parent[a][i];
-			int parent2 = bl_object.parent[b][i];
-			if (parent2 != parent1 && parent1 != -1 && parent2 != -1) {
-				a = parent1;
-				b = parent2;
-			}
-		}
-		return bl_object.parent[a][0];
-	}
+    int n;
+    BinaryLifting* bl;
+    vector<int> depth;
+
+    LCA(int n, vector<int>* edges, int root, BinaryLifting* bl)
+        : n(n), bl(bl), depth(n, 0) {
+        _dfs(root, -1, edges);
+    }
+
+    void _dfs(int u, int par, vector<int>* edges) {
+        for (int v : edges[u])
+            if (v != par) {
+                depth[v] = depth[u] + 1;
+                _dfs(v, u, edges);
+            }
+    }
+
+    int getLCA(int a, int b) {
+        if (depth[a] < depth[b]) swap(a, b);
+        a = bl->kthParent(a, depth[a] - depth[b]);
+        if (a == b) return a;
+        for (int j = bl->maxLog; j >= 0; j--)
+            if (bl->parent[a][j] != bl->parent[b][j]) {
+                a = bl->parent[a][j];
+                b = bl->parent[b][j];
+            }
+        return bl->parent[a][0];
+    }
 };

--- a/tests/test_binary_lifting.cpp
+++ b/tests/test_binary_lifting.cpp
@@ -1,0 +1,26 @@
+#include "common.h"
+#include "../Tree Algorithms/Binary_Lifting.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Linear chain: 0-1-2-3-4, rooted at 0
+    int n = 5;
+    vector<int> edges[5];
+    for (int i = 0; i < 4; i++) {
+        edges[i].push_back(i + 1);
+        edges[i + 1].push_back(i);
+    }
+
+    BinaryLifting bl(n, edges, n, 0);
+
+    ASSERT_EQ(bl.kthParent(4, 1), 3);
+    ASSERT_EQ(bl.kthParent(4, 2), 2);
+    ASSERT_EQ(bl.kthParent(4, 4), 0);
+    ASSERT_EQ(bl.kthParent(4, 5), -1);  // beyond root
+    ASSERT_EQ(bl.kthParent(0, 1), -1);  // root has no parent
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_centroid_tree.cpp
+++ b/tests/test_centroid_tree.cpp
@@ -1,0 +1,46 @@
+#include "common.h"
+#include "../Tree Algorithms/Centroid_Tree.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Path graph: 0-1-2-3-4 (5 nodes)
+    // Centroid of the full tree is node 2
+    int n = 5;
+    edgeList.clear();
+    deleted.clear();
+    subtree.resize(n);
+    fill(subtree.begin(), subtree.end(), 0);
+
+    vector<int> edges[5];
+    for (int i = 0; i < n - 1; i++) {
+        edges[i].push_back((int)edgeList.size());
+        edges[i + 1].push_back((int)edgeList.size());
+        edgeList.push_back({i, i + 1});
+        deleted.push_back(false);
+    }
+
+    int root = decompose(0, edges, new vector<int>[n], -1);
+    ASSERT_EQ(root, 2);  // centroid of 0-1-2-3-4 is node 2
+
+    // Star graph: center=0, leaves 1,2,3,4 — centroid is node 0
+    int n2 = 5;
+    edgeList.clear();
+    deleted.clear();
+    subtree.assign(n2, 0);
+
+    vector<int> edges2[5];
+    for (int i = 1; i < n2; i++) {
+        edges2[0].push_back((int)edgeList.size());
+        edges2[i].push_back((int)edgeList.size());
+        edgeList.push_back({0, i});
+        deleted.push_back(false);
+    }
+
+    int root2 = decompose(0, edges2, new vector<int>[n2], -1);
+    ASSERT_EQ(root2, 0);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_hld.cpp
+++ b/tests/test_hld.cpp
@@ -1,0 +1,39 @@
+#include "common.h"
+#include "../Tree Algorithms/HLD.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Tree:    0(5)
+    //         / \
+    //       1(3) 2(7)
+    //       / \
+    //     3(2) 4(4)
+    // Node values: [5, 3, 7, 2, 4]
+    // HLD supports path max queries
+    int n = 5;
+    vector<long long> values = {5, 3, 7, 2, 4};
+    vector<int> edges[5];
+    auto addEdge = [&](int u, int v) {
+        edges[u].push_back(v); edges[v].push_back(u);
+    };
+    addEdge(0, 1); addEdge(0, 2); addEdge(1, 3); addEdge(1, 4);
+
+    BinaryLifting bl(n, edges, n, 0);
+    LCA lca_obj(n, edges, 0, &bl);
+    HLD<Node1, Update1> hld(n, edges, 0, values, &lca_obj);
+
+    // Max on path 3->4: goes through 1 → max(2, 3, 4) = 4
+    ASSERT_EQ(hld.findAnswer(3, 4), 4LL);
+
+    // Max on path 3->2: 3->1->0->2 → max(2, 3, 5, 7) = 7
+    ASSERT_EQ(hld.findAnswer(3, 2), 7LL);
+
+    // Update node 1 value to 10, then max on path 3->4 = max(2, 10, 4) = 10
+    hld.makeUpdateatIndex(1, 10);
+    ASSERT_EQ(hld.findAnswer(3, 4), 10LL);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_lca_o1.cpp
+++ b/tests/test_lca_o1.cpp
@@ -1,0 +1,37 @@
+#include "common.h"
+#include "../Tree Algorithms/LCA_O_1.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Same tree as LCA_tree test:
+    //        0
+    //       / \
+    //      1   2
+    //     / \   \
+    //    3   4   5
+    int n = 6;
+    vector<int> edges[6];
+    auto addEdge = [&](int u, int v) {
+        edges[u].push_back(v); edges[v].push_back(u);
+    };
+    addEdge(0, 1); addEdge(0, 2); addEdge(1, 3);
+    addEdge(1, 4); addEdge(2, 5);
+
+    LCA_O_1 lca(n, edges, 0);
+
+    ASSERT_EQ(lca.query(3, 4), 1);
+    ASSERT_EQ(lca.query(3, 5), 0);
+    ASSERT_EQ(lca.query(4, 5), 0);
+    ASSERT_EQ(lca.query(0, 3), 0);
+    ASSERT_EQ(lca.query(3, 3), 3);
+
+    // Verify depths
+    ASSERT_EQ(lca.getDepth(0), 0);
+    ASSERT_EQ(lca.getDepth(1), 1);
+    ASSERT_EQ(lca.getDepth(3), 2);
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_lca_tree.cpp
+++ b/tests/test_lca_tree.cpp
@@ -1,0 +1,32 @@
+#include "common.h"
+#include "../Tree Algorithms/LCA_tree.cpp"
+
+using namespace std;
+
+int run_tests() {
+    // Tree:        0
+    //            /   \
+    //           1     2
+    //          / \     \
+    //         3   4     5
+    int n = 6;
+    vector<int> edges[6];
+    auto addEdge = [&](int u, int v) {
+        edges[u].push_back(v); edges[v].push_back(u);
+    };
+    addEdge(0, 1); addEdge(0, 2); addEdge(1, 3);
+    addEdge(1, 4); addEdge(2, 5);
+
+    BinaryLifting bl(n, edges, n, 0);
+    LCA lca(n, edges, 0, &bl);
+
+    ASSERT_EQ(lca.getLCA(3, 4), 1);  // siblings under 1
+    ASSERT_EQ(lca.getLCA(3, 5), 0);  // 3 is under 1, 5 is under 2
+    ASSERT_EQ(lca.getLCA(4, 5), 0);
+    ASSERT_EQ(lca.getLCA(0, 3), 0);  // root is ancestor of all
+    ASSERT_EQ(lca.getLCA(3, 3), 3);  // LCA of node with itself
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }


### PR DESCRIPTION
## Summary

Chains onto PR5. Contains **5 algorithm files**.

- **`Binary_Lifting.cpp`**: clean `BinaryLifting` struct; remove old `logValues` precomputation branch
- **`LCA_tree.cpp`**: `LCA` struct built on `BinaryLifting`; both in one self-contained file
- **`LCA_O_1.cpp`**: Euler tour + `SparseTable<MinNode>`; O(1) LCA query
- **`HLD.cpp`**: full Heavy-Light Decomposition with embedded `BinaryLifting`, `LCA`, `SegTree`
- **`Centroid_Tree.cpp`**: extract `decompose()` from `main()`; uses `edgeList` index approach; global state (`edgeList`, `deleted`, `subtree`) kept as the caller initialises them

All: `#include <bits/stdc++.h>`, `using namespace std`, no `static` helpers.

**5 test files** — one per template.

## Test plan

- [ ] `make -C tests run` — 17 tests pass (12 from prior PRs + 5 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_