### PR TITLE
PR4b: Refactor Lazy_SGT.cpp + add test

### DIFF
--- a/Range Queries/Lazy_SGT.cpp
+++ b/Range Queries/Lazy_SGT.cpp
@@ -1,6 +1,6 @@
 // Lazy Segment Tree — O(N) build, O(log N) range update and range query
-// Customise Node1 (merge, identity) and Update1 (apply, combine, identity) for your problem.
-// Example below: range-assign with range-sum queries.
+// Supports multiple Segment Trees with just a change in Node and Update
+// Very few changes required each time
 #include <bits/stdc++.h>
 using namespace std;
 
@@ -9,9 +9,10 @@ struct LazySGT {
     vector<Node> tree;
     vector<bool> lazy;
     vector<Update> updates;
-    int n, s;
+    int n;
+    int s;
 
-    LazySGT(int n, vector<long long>& a) {
+    LazySGT(int n, vector<long long>& a) { // change if type updated
         this->n = n;
         s = 1;
         while (s < 2 * n) s <<= 1;
@@ -21,7 +22,7 @@ struct LazySGT {
         _build(a, 0, n - 1, 1);
     }
 
-    void _build(vector<long long>& a, int l, int r, int idx) {
+    void _build(vector<long long>& a, int l, int r, int idx) { // Never change this
         if (l == r) { tree[idx] = Node(a[l]); return; }
         int m = (l + r) / 2;
         _build(a, l, m, 2 * idx);
@@ -29,12 +30,15 @@ struct LazySGT {
         tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
     }
 
-    void _apply(int idx, int l, int r, Update& u) {
-        if (l != r) { lazy[idx] = true; updates[idx].combine(u, l, r); }
+    void _apply(int idx, int l, int r, Update& u) { // Never change this
+        if (l != r) {
+            lazy[idx] = true;
+            updates[idx].combine(u, l, r);
+        }
         u.apply(tree[idx], l, r);
     }
 
-    void _pushdown(int idx, int l, int r) {
+    void _pushdown(int idx, int l, int r) { // Never change this
         if (lazy[idx]) {
             int m = (l + r) / 2;
             _apply(2 * idx, l, m, updates[idx]);
@@ -44,7 +48,7 @@ struct LazySGT {
         }
     }
 
-    void _update(int l, int r, int idx, int ql, int qr, Update& u) {
+    void _update(int l, int r, int idx, int ql, int qr, Update& u) { // Never change this
         if (l > qr || r < ql) return;
         if (l >= ql && r <= qr) { _apply(idx, l, r, u); return; }
         _pushdown(idx, l, r);
@@ -54,7 +58,7 @@ struct LazySGT {
         tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
     }
 
-    Node _query(int l, int r, int idx, int ql, int qr) {
+    Node _query(int l, int r, int idx, int ql, int qr) { // Never change this
         if (l > qr || r < ql) return Node();
         if (l >= ql && r <= qr) { _pushdown(idx, l, r); return tree[idx]; }
         _pushdown(idx, l, r);
@@ -66,8 +70,8 @@ struct LazySGT {
         return ans;
     }
 
-    void make_update(int l, int r, long long val) {
-        Update u(val);
+    void make_update(int l, int r, long long val) { // pass in as many parameters as required
+        Update u(val); // may change
         _update(0, n - 1, 1, l, r, u);
     }
 
@@ -78,15 +82,29 @@ struct LazySGT {
 
 // Example: range-assign update, range-sum query
 struct Node1 {
-    long long val = 0;
-    Node1() = default;
-    Node1(long long v) : val(v) {}
-    void merge(const Node1& l, const Node1& r) { val = l.val + r.val; }
+    long long val; // may change
+    Node1() { // Identity element
+        val = 0; // may change
+    }
+    Node1(long long v) { // Actual Node
+        val = v; // may change
+    }
+    void merge(Node1& l, Node1& r) { // Merge two child nodes
+        val = l.val + r.val; // may change
+    }
 };
 struct Update1 {
-    long long val = 0;
-    Update1() = default;
-    Update1(long long v) : val(v) {}
-    void apply(Node1& a, int l, int r) { a.val = val * (r - l + 1); }
-    void combine(const Update1& newer, int /*l*/, int /*r*/) { val = newer.val; }
+    long long val; // may change
+    Update1() { // Identity update
+        val = 0; // may change
+    }
+    Update1(long long v) { // Actual Update
+        val = v; // may change
+    }
+    void apply(Node1& a, int l, int r) { // apply update to given node
+        a.val = val * (r - l + 1); // may change
+    }
+    void combine(Update1& newer, int l, int r) { // combine with incoming update
+        val = newer.val; // may change
+    }
 };

--- a/Range Queries/Lazy_SGT.cpp
+++ b/Range Queries/Lazy_SGT.cpp
@@ -1,116 +1,92 @@
-// Credits to HealthyUG for the inspiration.
-// Lazy Segment Tree with Range Updates and Range Queries
-// Supports multiple Segment Trees with just a change in the Node and Update
-// Very few changes required everytime
+// Lazy Segment Tree — O(N) build, O(log N) range update and range query
+// Customise Node1 (merge, identity) and Update1 (apply, combine, identity) for your problem.
+// Example below: range-assign with range-sum queries.
+#include <bits/stdc++.h>
+using namespace std;
 
 template<typename Node, typename Update>
 struct LazySGT {
     vector<Node> tree;
     vector<bool> lazy;
     vector<Update> updates;
-    vector<ll> arr; // type may change
-    int n;
-    int s;
-    LazySGT(int a_len, vector<ll> &a) { // change if type updated
-        arr = a;
-        n = a_len;
+    int n, s;
+
+    LazySGT(int n, vector<long long>& a) {
+        this->n = n;
         s = 1;
-        while(s < 2 * n){
-            s = s << 1;
-        }
-        tree.resize(s); fill(all(tree), Node());
-        lazy.resize(s); fill(all(lazy), false);
-        updates.resize(s); fill(all(updates), Update());
-        build(0, n - 1, 1);
+        while (s < 2 * n) s <<= 1;
+        tree.resize(s, Node());
+        lazy.resize(s, false);
+        updates.resize(s, Update());
+        _build(a, 0, n - 1, 1);
     }
-    void build(int start, int end, int index) { // Never change this
-        if (start == end)   {
-            tree[index] = Node(arr[start]);
-            return;
-        }
-        int mid = (start + end) / 2;
-        build(start, mid, 2 * index);
-        build(mid + 1, end, 2 * index + 1);
-        tree[index].merge(tree[2 * index], tree[2 * index + 1]);
+
+    void _build(vector<long long>& a, int l, int r, int idx) {
+        if (l == r) { tree[idx] = Node(a[l]); return; }
+        int m = (l + r) / 2;
+        _build(a, l, m, 2 * idx);
+        _build(a, m + 1, r, 2 * idx + 1);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
     }
-    void pushdown(int index, int start, int end){
-        if(lazy[index]){
-            int mid = (start + end) / 2;
-            apply(2 * index, start, mid, updates[index]);
-            apply(2 * index + 1, mid + 1, end, updates[index]);
-            updates[index] = Update();
-            lazy[index] = 0;
+
+    void _apply(int idx, int l, int r, Update& u) {
+        if (l != r) { lazy[idx] = true; updates[idx].combine(u, l, r); }
+        u.apply(tree[idx], l, r);
+    }
+
+    void _pushdown(int idx, int l, int r) {
+        if (lazy[idx]) {
+            int m = (l + r) / 2;
+            _apply(2 * idx, l, m, updates[idx]);
+            _apply(2 * idx + 1, m + 1, r, updates[idx]);
+            updates[idx] = Update();
+            lazy[idx] = false;
         }
     }
-    void apply(int index, int start, int end, Update& u){
-        if(start != end){
-            lazy[index] = 1;
-            updates[index].combine(u, start, end);
-        }
-        u.apply(tree[index], start, end);
+
+    void _update(int l, int r, int idx, int ql, int qr, Update& u) {
+        if (l > qr || r < ql) return;
+        if (l >= ql && r <= qr) { _apply(idx, l, r, u); return; }
+        _pushdown(idx, l, r);
+        int m = (l + r) / 2;
+        _update(l, m, 2 * idx, ql, qr, u);
+        _update(m + 1, r, 2 * idx + 1, ql, qr, u);
+        tree[idx].merge(tree[2 * idx], tree[2 * idx + 1]);
     }
-    void update(int start, int end, int index, int left, int right, Update& u) {  // Never Change this
-        if(start > right || end < left)
-            return;
-        if(start >= left && end <= right){
-            apply(index, start, end, u);
-            return;
-        }
-        pushdown(index, start, end);
-        int mid = (start + end) / 2;
-        update(start, mid, 2 * index, left, right, u);
-        update(mid + 1, end, 2 * index + 1, left, right, u);
-        tree[index].merge(tree[2 * index], tree[2 * index + 1]);
-    }
-    Node query(int start, int end, int index, int left, int right) { // Never change this
-        if (start > right || end < left)
-            return Node();
-        if (start >= left && end <= right){
-            pushdown(index, start, end);
-            return tree[index];
-        }
-        pushdown(index, start, end);
-        int mid = (start + end) / 2;
-        Node l, r, ans;
-        l = query(start, mid, 2 * index, left, right);
-        r = query(mid + 1, end, 2 * index + 1, left, right);
-        ans.merge(l, r);
+
+    Node _query(int l, int r, int idx, int ql, int qr) {
+        if (l > qr || r < ql) return Node();
+        if (l >= ql && r <= qr) { _pushdown(idx, l, r); return tree[idx]; }
+        _pushdown(idx, l, r);
+        int m = (l + r) / 2;
+        Node left = _query(l, m, 2 * idx, ql, qr);
+        Node right = _query(m + 1, r, 2 * idx + 1, ql, qr);
+        Node ans;
+        ans.merge(left, right);
         return ans;
     }
-    void make_update(int left, int right, ll val) {  // pass in as many parameters as required
-        Update new_update = Update(val); // may change
-        update(0, n - 1, 1, left, right, new_update);
+
+    void make_update(int l, int r, long long val) {
+        Update u(val);
+        _update(0, n - 1, 1, l, r, u);
     }
-    Node make_query(int left, int right) {
-        return query(0, n - 1, 1, left, right);
+
+    Node make_query(int l, int r) {
+        return _query(0, n - 1, 1, l, r);
     }
 };
 
+// Example: range-assign update, range-sum query
 struct Node1 {
-    ll val; // may change
-    Node1() { // Identity element
-        val = 0;    // may change
-    }
-    Node1(ll p1) {  // Actual Node
-        val = p1; // may change
-    }
-    void merge(Node1 &l, Node1 &r) { // Merge two child nodes
-        val = l.val + r.val;  // may change
-    }
+    long long val = 0;
+    Node1() = default;
+    Node1(long long v) : val(v) {}
+    void merge(const Node1& l, const Node1& r) { val = l.val + r.val; }
 };
-
 struct Update1 {
-    ll val; // may change
-    Update1(){ // Identity update
-        val = 0;
-    }
-    Update1(ll val1) { // Actual Update
-        val = val1;
-    }
-    void apply(Node1 &a, int start, int end) { // apply update to given node
-        a.val = val * (end - start + 1); // may change
-    }
-    void combine(Update1& new_update, int start, int end){
-        val = new_update.val;
-    }
+    long long val = 0;
+    Update1() = default;
+    Update1(long long v) : val(v) {}
+    void apply(Node1& a, int l, int r) { a.val = val * (r - l + 1); }
+    void combine(const Update1& newer, int /*l*/, int /*r*/) { val = newer.val; }
 };

--- a/tests/test_lazy_sgt.cpp
+++ b/tests/test_lazy_sgt.cpp
@@ -1,13 +1,8 @@
 #include "common.h"
+#include "range_utils.h"
 #include "../Range Queries/Lazy_SGT.cpp"
 
 using namespace std;
-
-long long brute_sum(vector<long long>& a, int l, int r) {
-    long long res = 0;
-    for (int i = l; i <= r; i++) res += a[i];
-    return res;
-}
 
 int run_tests() {
     // --- Small test: [1, 2, 3, 4, 5], range-assign, range-sum ---
@@ -20,7 +15,7 @@ int run_tests() {
 
         // Assign [1,3] = 10 → [1, 10, 10, 10, 5]
         sgt.make_update(1, 3, 10);
-        for (int i = 1; i <= 3; i++) a[i] = 10;
+        range_assign(a, 1, 3, 10);
         ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
         ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
         ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
@@ -28,7 +23,7 @@ int run_tests() {
 
         // Assign entire array = 3
         sgt.make_update(0, 4, 3);
-        for (int i = 0; i <= 4; i++) a[i] = 3;
+        range_assign(a, 0, 4, 3);
         ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
         ASSERT_EQ(sgt.make_query(2, 4).val, brute_sum(a, 2, 4));
     }
@@ -39,10 +34,10 @@ int run_tests() {
         LazySGT<Node1, Update1> sgt(1, a);
         ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
         sgt.make_update(0, 0, 100);
-        a[0] = 100;
+        range_assign(a, 0, 0, 100);
         ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
         sgt.make_update(0, 0, 0);
-        a[0] = 0;
+        range_assign(a, 0, 0, 0);
         ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
     }
 
@@ -52,7 +47,7 @@ int run_tests() {
         LazySGT<Node1, Update1> sgt(6, a);
         ASSERT_EQ(sgt.make_query(0, 5).val, brute_sum(a, 0, 5));
         sgt.make_update(2, 4, 5);
-        for (int i = 2; i <= 4; i++) a[i] = 5;
+        range_assign(a, 2, 4, 5);
         ASSERT_EQ(sgt.make_query(0, 5).val, brute_sum(a, 0, 5));
         ASSERT_EQ(sgt.make_query(2, 4).val, brute_sum(a, 2, 4));
         ASSERT_EQ(sgt.make_query(0, 1).val, brute_sum(a, 0, 1));
@@ -64,9 +59,9 @@ int run_tests() {
         vector<long long> a(5, 0);
         LazySGT<Node1, Update1> sgt(5, a);
         sgt.make_update(0, 4, 10);
-        for (int i = 0; i <= 4; i++) a[i] = 10;
+        range_assign(a, 0, 4, 10);
         sgt.make_update(1, 3, 20);
-        for (int i = 1; i <= 3; i++) a[i] = 20;
+        range_assign(a, 1, 3, 20);
         // array = [10, 20, 20, 20, 10]
         ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
         ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
@@ -79,14 +74,14 @@ int run_tests() {
         vector<long long> a(8, 1);
         LazySGT<Node1, Update1> sgt(8, a);
         sgt.make_update(0, 7, 5);
-        for (int i = 0; i <= 7; i++) a[i] = 5;
+        range_assign(a, 0, 7, 5);
         ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
         sgt.make_update(2, 5, 3);
-        for (int i = 2; i <= 5; i++) a[i] = 3;
+        range_assign(a, 2, 5, 3);
         ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
         ASSERT_EQ(sgt.make_query(2, 5).val, brute_sum(a, 2, 5));
         sgt.make_update(0, 7, 7);
-        for (int i = 0; i <= 7; i++) a[i] = 7;
+        range_assign(a, 0, 7, 7);
         ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
         ASSERT_EQ(sgt.make_query(3, 3).val, brute_sum(a, 3, 3));
     }
@@ -97,7 +92,7 @@ int run_tests() {
         LazySGT<Node1, Update1> sgt(8, a);
         ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
         sgt.make_update(4, 7, 0);
-        for (int i = 4; i <= 7; i++) a[i] = 0;
+        range_assign(a, 4, 7, 0);
         ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
         ASSERT_EQ(sgt.make_query(4, 7).val, brute_sum(a, 4, 7));
         ASSERT_EQ(sgt.make_query(0, 3).val, brute_sum(a, 0, 3));
@@ -109,7 +104,7 @@ int run_tests() {
         LazySGT<Node1, Update1> sgt(7, a);
         for (long long v = 1; v <= 10; v++) {
             sgt.make_update(0, 6, v);
-            for (int i = 0; i <= 6; i++) a[i] = v;
+            range_assign(a, 0, 6, v);
             ASSERT_EQ(sgt.make_query(0, 6).val, brute_sum(a, 0, 6));
         }
     }
@@ -119,13 +114,13 @@ int run_tests() {
         vector<long long> a(5, 0);
         LazySGT<Node1, Update1> sgt(5, a);
         sgt.make_update(2, 2, 99);
-        a[2] = 99;
+        range_assign(a, 2, 2, 99);
         ASSERT_EQ(sgt.make_query(2, 2).val, brute_sum(a, 2, 2));
         ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
         sgt.make_update(0, 0, 1);
-        a[0] = 1;
+        range_assign(a, 0, 0, 1);
         sgt.make_update(4, 4, 1);
-        a[4] = 1;
+        range_assign(a, 4, 4, 1);
         ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
     }
 
@@ -143,7 +138,7 @@ int run_tests() {
             if (l > r) swap(l, r);
             if (rng() % 2 == 0) {
                 long long val = rng() % 1000;
-                for (int i = l; i <= r; i++) a[i] = val;
+                range_assign(a, l, r, val);
                 sgt.make_update(l, r, val);
             } else {
                 long long got = sgt.make_query(l, r).val;

--- a/tests/test_lazy_sgt.cpp
+++ b/tests/test_lazy_sgt.cpp
@@ -1,0 +1,160 @@
+#include "common.h"
+#include "../Range Queries/Lazy_SGT.cpp"
+
+using namespace std;
+
+long long brute_sum(vector<long long>& a, int l, int r) {
+    long long res = 0;
+    for (int i = l; i <= r; i++) res += a[i];
+    return res;
+}
+
+int run_tests() {
+    // --- Small test: [1, 2, 3, 4, 5], range-assign, range-sum ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5};
+        LazySGT<Node1, Update1> sgt(5, a);
+
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
+
+        // Assign [1,3] = 10 → [1, 10, 10, 10, 5]
+        sgt.make_update(1, 3, 10);
+        for (int i = 1; i <= 3; i++) a[i] = 10;
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+        ASSERT_EQ(sgt.make_query(4, 4).val, brute_sum(a, 4, 4));
+
+        // Assign entire array = 3
+        sgt.make_update(0, 4, 3);
+        for (int i = 0; i <= 4; i++) a[i] = 3;
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(2, 4).val, brute_sum(a, 2, 4));
+    }
+
+    // --- Single element array ---
+    {
+        vector<long long> a = {7};
+        LazySGT<Node1, Update1> sgt(1, a);
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+        sgt.make_update(0, 0, 100);
+        a[0] = 100;
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+        sgt.make_update(0, 0, 0);
+        a[0] = 0;
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+    }
+
+    // --- All zeros, assign to non-zero ---
+    {
+        vector<long long> a(6, 0);
+        LazySGT<Node1, Update1> sgt(6, a);
+        ASSERT_EQ(sgt.make_query(0, 5).val, brute_sum(a, 0, 5));
+        sgt.make_update(2, 4, 5);
+        for (int i = 2; i <= 4; i++) a[i] = 5;
+        ASSERT_EQ(sgt.make_query(0, 5).val, brute_sum(a, 0, 5));
+        ASSERT_EQ(sgt.make_query(2, 4).val, brute_sum(a, 2, 4));
+        ASSERT_EQ(sgt.make_query(0, 1).val, brute_sum(a, 0, 1));
+        ASSERT_EQ(sgt.make_query(5, 5).val, brute_sum(a, 5, 5));
+    }
+
+    // --- Overlapping range updates ---
+    {
+        vector<long long> a(5, 0);
+        LazySGT<Node1, Update1> sgt(5, a);
+        sgt.make_update(0, 4, 10);
+        for (int i = 0; i <= 4; i++) a[i] = 10;
+        sgt.make_update(1, 3, 20);
+        for (int i = 1; i <= 3; i++) a[i] = 20;
+        // array = [10, 20, 20, 20, 10]
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        ASSERT_EQ(sgt.make_query(0, 0).val, brute_sum(a, 0, 0));
+        ASSERT_EQ(sgt.make_query(1, 3).val, brute_sum(a, 1, 3));
+        ASSERT_EQ(sgt.make_query(4, 4).val, brute_sum(a, 4, 4));
+    }
+
+    // --- Nested range updates: outer then inner then outer again ---
+    {
+        vector<long long> a(8, 1);
+        LazySGT<Node1, Update1> sgt(8, a);
+        sgt.make_update(0, 7, 5);
+        for (int i = 0; i <= 7; i++) a[i] = 5;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        sgt.make_update(2, 5, 3);
+        for (int i = 2; i <= 5; i++) a[i] = 3;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        ASSERT_EQ(sgt.make_query(2, 5).val, brute_sum(a, 2, 5));
+        sgt.make_update(0, 7, 7);
+        for (int i = 0; i <= 7; i++) a[i] = 7;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        ASSERT_EQ(sgt.make_query(3, 3).val, brute_sum(a, 3, 3));
+    }
+
+    // --- Power-of-two size ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5, 6, 7, 8};
+        LazySGT<Node1, Update1> sgt(8, a);
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        sgt.make_update(4, 7, 0);
+        for (int i = 4; i <= 7; i++) a[i] = 0;
+        ASSERT_EQ(sgt.make_query(0, 7).val, brute_sum(a, 0, 7));
+        ASSERT_EQ(sgt.make_query(4, 7).val, brute_sum(a, 4, 7));
+        ASSERT_EQ(sgt.make_query(0, 3).val, brute_sum(a, 0, 3));
+    }
+
+    // --- Consecutive full-array reassignments ---
+    {
+        vector<long long> a = {1, 2, 3, 4, 5, 6, 7};
+        LazySGT<Node1, Update1> sgt(7, a);
+        for (long long v = 1; v <= 10; v++) {
+            sgt.make_update(0, 6, v);
+            for (int i = 0; i <= 6; i++) a[i] = v;
+            ASSERT_EQ(sgt.make_query(0, 6).val, brute_sum(a, 0, 6));
+        }
+    }
+
+    // --- Point-level assigns via single-index range update ---
+    {
+        vector<long long> a(5, 0);
+        LazySGT<Node1, Update1> sgt(5, a);
+        sgt.make_update(2, 2, 99);
+        a[2] = 99;
+        ASSERT_EQ(sgt.make_query(2, 2).val, brute_sum(a, 2, 2));
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+        sgt.make_update(0, 0, 1);
+        a[0] = 1;
+        sgt.make_update(4, 4, 1);
+        a[4] = 1;
+        ASSERT_EQ(sgt.make_query(0, 4).val, brute_sum(a, 0, 4));
+    }
+
+    // --- Stress test: n=300, random range-assign + range-sum queries ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        const int n = 300;
+        vector<long long> a(n, 0);
+        LazySGT<Node1, Update1> sgt(n, a);
+
+        for (int iter = 0; iter < 600; iter++) {
+            int l = rng() % n;
+            int r = rng() % n;
+            if (l > r) swap(l, r);
+            if (rng() % 2 == 0) {
+                long long val = rng() % 1000;
+                for (int i = l; i <= r; i++) a[i] = val;
+                sgt.make_update(l, r, val);
+            } else {
+                long long got = sgt.make_query(l, r).val;
+                long long expected = brute_sum(a, l, r);
+                if (got != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
+                ASSERT_EQ(got, expected);
+            }
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }


### PR DESCRIPTION
## Summary

Chains onto PR4a.

- Remove old `arr` member, macros, and boilerplate
- `#include <bits/stdc++.h>`, `using namespace std`
- Constructor initialises `n` and `s` in the body (no initializer list)
- `make_update` and `make_query` expanded to multi-line
- Internal helpers renamed to `_build`, `_update`, `_query`, `_pushdown`, `_apply` (no `static`)

**`test_lazy_sgt.cpp`**: `brute_sum` helper; a reference `vector<long long> a` is kept in sync with every `make_update` call so all assertions compare against `brute_sum` rather than hardcoded values; stress test (n=300, 600 iterations) uses a chrono seed printed on failure.

## Test plan

- [ ] `make -C tests run` — 5 tests pass (4 from prior PRs + 1 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_