### PR TITLE
PR4d: Refactor Mo_algo.cpp + add test

### DIFF
--- a/Range Queries/Mo_algo.cpp
+++ b/Range Queries/Mo_algo.cpp
@@ -1,141 +1,53 @@
-/* Priyansh Agarwal*/
-#include<bits/stdc++.h>
-#include<ext/pb_ds/assoc_container.hpp>
-#include<ext/pb_ds/tree_policy.hpp>
-#include<algorithm>
-#include<unordered_map>
-#include<vector>
-#include<unordered_set>
-#include<set>
-#include<map>
-#include<queue>
-#include<stack>
-#include<map>
-#include<chrono>
+// O((N+Q)√N) — Mo's Algorithm for offline range queries (distinct count example)
+// arr: input array (0-indexed); queries: list of {l, r} inclusive ranges
+// Returns answer[i] = number of distinct elements in arr[queries[i].l .. queries[i].r]
+#include <bits/stdc++.h>
 using namespace std;
-using namespace __gnu_pbds;
-using namespace chrono;
-#define fastio() ios_base::sync_with_stdio(false);cin.tie(NULL);cout.tie(NULL)
-#define MOD 1000000007
-#define MOD1 998244353
-#define nline "\n"
-#define pb push_back
-#define mp make_pair
-#define ff first
-#define ss second
-#define PI 3.141592653589793238462
-#define debug(x) cout << #x << " " << x <<endl;
-#define set_bits __builtin_popcount
-typedef long long ll;
-typedef unsigned long long ull;
-typedef long double lld;
-typedef tree<int, null_type, less<int>, rb_tree_tag, tree_order_statistics_node_update > pbds;
-/*---------------------------------------------------------------------------------------------------------------------------*/
-ll gcd(ll a, ll b) {if (b > a) {return gcd(b, a);} if (b == 0) {return a;} return gcd(b, a % b);}
-ll expo(ll a, ll b, ll mod) {ll res = 1; while (b > 0) {if (b & 1)res = (res * a) % mod; a = (a * a) % mod; b = b >> 1;} return res;}
-void extendgcd(ll a, ll b, ll*v) {if (b == 0) {v[0] = 1; v[1] = 0; v[2] = a; return ;} extendgcd(b, a % b, v); ll x = v[1]; v[1] = v[0] - v[1] * (a / b); v[0] = x; return;} //pass an arry of size 3
-ll mminv(ll a, ll b) {ll arr[3]; extendgcd(a, b, arr); return arr[0];} //for non prime b
-ll mminvprime(ll a, ll b) {return expo(a, b - 2, b);}
-bool revsort(ll a, ll b) {return a > b;}
-void swap(int &x, int &y) {int temp = x; x = y; y = temp;}
-ll combination(ll n, ll r, ll m, ll* fact) {ll val1 = fact[n]; ll val2 = mminvprime(fact[r], m); ll val3 = mminvprime(fact[n - r], m); return ((val1 * val2) % m * val3) % m;}
-void google(int t) {cout << "Case #" << t << ": ";}
-vector<int> sieve(int n) {int*arr = new int[n + 1](); vector<int> vect; for (int i = 2; i <= n; i++)if (arr[i] == 0) {vect.push_back(i); for (int j = 2 * i; j <= n; j += i)arr[j] = 1;} return vect;}
-/*--------------------------------------------------------------------------------------------------------------------------*/
-const int block_size = 450;
-bool compare(pair<pair<int, int>, int> p1, pair<pair<int, int>, int> p2)
-{
-	int b1 = p1.ff.ff / block_size;
-	int b2 = p2.ff.ff / block_size;
-	if (b1 == b2)
-		return b1 % 2 == 0 ? (p1.ff.ss < p2.ff.ss) : (p1.ff.ss > p2.ff.ss);
-	return b1 < b2;
-}
-int main()
-{
-	fastio();
-#ifndef ONLINE_JUDGE
-	freopen("Input.txt", "r", stdin);
-	freopen("Output.txt", "w", stdout);
-	freopen("Error.txt", "w", stderr);
-#endif
-	auto start1 = high_resolution_clock::now();
-	int n, q;
-	cin >> n >> q;
-	// block_size = int(sqrt(n + 0.0) + 1);
-	int *arr = new int[n];
-	int *freq = new int[n + 1]();
-	int number = 1;
-	map<int, int> coordinate_compression;
-	for (int i = 0; i < n; i++)
-	{
-		cin >> arr[i];
-		if (coordinate_compression.find(arr[i]) == coordinate_compression.end())
-		{
-			coordinate_compression[arr[i]] = number;
-			arr[i] = number;
-			number++;
-		}
-		else
-			arr[i] = coordinate_compression[arr[i]];
-	}
-	int start = 0;
-	int end = -1;
-	vector<pair<pair<int, int>, int>> ans(q);
-	for (int i = 0; i < q; i ++)
-	{
-		int a, b;
-		cin >> a >> b;
-		ans[i] = {{a, b}, i};
-	}
-	sort(ans.begin(), ans.end(), compare);
-	int *ans1 = new int[q];
-	int count = 0;
-	for (auto i : ans)
-	{
-		pair<pair<int, int>, int> p1 = i;
-		int right = p1.ff.ss - 1;
-		int left = p1.ff.ff - 1;
-		while (start < left)
-		{
-			int x = arr[start];
-			freq[x]--;
-			if (freq[x] == 0)
-				count--;
-			start++;
-		}
-		while (start > left)
-		{
-			start--;
-			int x = arr[start];
-			freq[x]++;
-			if (freq[x] == 1)
-				count++;
-		}
-		while (end < right)
-		{
-			end++;
-			int x = arr[end];
-			freq[x]++;
-			if (freq[x] == 1)
-				count++;
-		}
-		while (end > right)
-		{
-			int x = arr[end];
-			freq[x]--;
-			if (freq[x] == 0)
-				count--;
-			end--;
-		}
-		ans1[p1.ss] = count;
-	}
-	for (int i = 0; i < q; i++)
-		cout << ans1[i] << "\n";
-	auto stop1 = high_resolution_clock::now();
-	auto duration = duration_cast<microseconds>(stop1 - start1);
-#ifndef ONLINE_JUDGE
-	cerr << "Time: " << duration.count() / 1000.0 << endl;
-#endif
-	return 0;
+
+vector<int> moDistinctQueries(int n, vector<int> arr, vector<pair<int, int>>& queries) {
+    const int block = max(1, (int)sqrt(n));
+    int q = (int)queries.size();
+
+    // Coordinate compress arr
+    map<int, int> compress;
+    int id = 0;
+    for (int& x : arr) {
+        if (!compress.count(x)) compress[x] = id++;
+        x = compress[x];
+    }
+
+    // Tag queries with original index, then sort by Mo's order
+    vector<pair<pair<int, int>, int>> indexed(q);
+    for (int i = 0; i < q; i++) indexed[i] = {{queries[i].first, queries[i].second}, i};
+
+    // Sort: primary key = block of l; secondary key = r, alternating direction
+    // per block (odd blocks descending) to reduce total pointer movement
+    auto moCmp = [&](const auto& a, const auto& b) {
+        int ba = a.first.first / block;
+        int bb = b.first.first / block;
+        if (ba != bb) return ba < bb;
+        return (ba & 1) ? a.first.second > b.first.second
+                        : a.first.second < b.first.second;
+    };
+    sort(indexed.begin(), indexed.end(), moCmp);
+
+    vector<int> freq(n, 0), ans(q);
+    int cur = 0, lo = 0, hi = -1;
+
+    auto add = [&](int pos) {
+        if (++freq[arr[pos]] == 1) cur++;
+    };
+    auto rem = [&](int pos) {
+        if (--freq[arr[pos]] == 0) cur--;
+    };
+
+    for (auto& [range, origIdx] : indexed) {
+        auto [l, r] = range;
+        while (hi < r) add(++hi);
+        while (lo > l) add(--lo);
+        while (hi > r) rem(hi--);
+        while (lo < l) rem(lo++);
+        ans[origIdx] = cur;
+    }
+    return ans;
 }

--- a/tests/test_mo_algo.cpp
+++ b/tests/test_mo_algo.cpp
@@ -1,0 +1,145 @@
+#include "common.h"
+#include "../Range Queries/Mo_algo.cpp"
+
+using namespace std;
+
+int brute_distinct(vector<int>& arr, int l, int r) {
+    set<int> s(arr.begin() + l, arr.begin() + r + 1);
+    return (int)s.size();
+}
+
+int run_tests() {
+    // --- Small test: [1, 2, 3, 2, 1, 4, 3] ---
+    {
+        vector<int> arr = {1, 2, 3, 2, 1, 4, 3};
+        vector<pair<int, int>> queries = {{0, 2}, {1, 4}, {0, 6}, {3, 5}};
+        vector<int> ans = moDistinctQueries(7, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 1, 4));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 0, 6));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 3, 5));
+    }
+
+    // --- Single element queries ---
+    {
+        vector<int> arr = {5, 5, 5, 5};
+        vector<pair<int, int>> queries = {{0, 0}, {1, 1}, {2, 3}};
+        vector<int> ans = moDistinctQueries(4, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 0));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 1, 1));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 2, 3));
+    }
+
+    // --- All distinct elements ---
+    {
+        vector<int> arr = {10, 20, 30, 40, 50};
+        vector<pair<int, int>> queries = {{0, 4}, {0, 2}, {2, 4}, {1, 3}};
+        vector<int> ans = moDistinctQueries(5, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 4));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 2, 4));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 1, 3));
+    }
+
+    // --- All same elements ---
+    {
+        vector<int> arr = {7, 7, 7, 7, 7, 7};
+        vector<pair<int, int>> queries = {{0, 5}, {0, 0}, {2, 4}, {1, 5}};
+        vector<int> ans = moDistinctQueries(6, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 5));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 0));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 2, 4));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 1, 5));
+    }
+
+    // --- Two elements alternating ---
+    {
+        vector<int> arr = {1, 2, 1, 2, 1, 2};
+        vector<pair<int, int>> queries = {{0, 5}, {0, 0}, {0, 1}, {1, 4}};
+        vector<int> ans = moDistinctQueries(6, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 5));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 0));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 0, 1));
+        ASSERT_EQ(ans[3], brute_distinct(arr, 1, 4));
+    }
+
+    // --- Large values (coordinate compression must handle these) ---
+    {
+        vector<int> arr = {1000000, 999999, 1000000, 999998, 999999};
+        vector<pair<int, int>> queries = {{0, 4}, {0, 2}, {1, 3}};
+        vector<int> ans = moDistinctQueries(5, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 4));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 1, 3));
+    }
+
+    // --- Single query spanning full array ---
+    {
+        vector<int> arr = {3, 1, 4, 1, 5, 9, 2, 6};
+        vector<pair<int, int>> queries = {{0, 7}};
+        vector<int> ans = moDistinctQueries(8, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 7));
+    }
+
+    // --- Many queries on same range (order preserved) ---
+    {
+        vector<int> arr = {1, 2, 3};
+        vector<pair<int, int>> queries = {{0, 2}, {0, 2}, {0, 2}};
+        vector<int> ans = moDistinctQueries(3, arr, queries);
+        ASSERT_EQ(ans[0], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[1], brute_distinct(arr, 0, 2));
+        ASSERT_EQ(ans[2], brute_distinct(arr, 0, 2));
+    }
+
+    // --- Stress test: n=500, q=200, values in [0,49] ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        const int n = 500;
+        vector<int> arr(n);
+        for (int i = 0; i < n; i++) arr[i] = rng() % 50;
+
+        const int q = 200;
+        vector<pair<int, int>> queries(q);
+        for (int i = 0; i < q; i++) {
+            int l = rng() % n, r = rng() % n;
+            if (l > r) swap(l, r);
+            queries[i] = {l, r};
+        }
+
+        vector<int> ans = moDistinctQueries(n, arr, queries);
+        for (int i = 0; i < q; i++) {
+            int expected = brute_distinct(arr, queries[i].first, queries[i].second);
+            if (ans[i] != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
+            ASSERT_EQ(ans[i], expected);
+        }
+    }
+
+    // --- Stress test: n=300, q=300, large value range ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        const int n = 300;
+        vector<int> arr(n);
+        for (int i = 0; i < n; i++) arr[i] = rng() % 1000000;
+
+        const int q = 300;
+        vector<pair<int, int>> queries(q);
+        for (int i = 0; i < q; i++) {
+            int l = rng() % n, r = rng() % n;
+            if (l > r) swap(l, r);
+            queries[i] = {l, r};
+        }
+
+        vector<int> ans = moDistinctQueries(n, arr, queries);
+        for (int i = 0; i < q; i++) {
+            int expected = brute_distinct(arr, queries[i].first, queries[i].second);
+            if (ans[i] != expected) cerr << "Stress test failed (seed=" << seed << ")\n";
+            ASSERT_EQ(ans[i], expected);
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/test_mo_algo.cpp
+++ b/tests/test_mo_algo.cpp
@@ -1,12 +1,8 @@
 #include "common.h"
+#include "range_utils.h"
 #include "../Range Queries/Mo_algo.cpp"
 
 using namespace std;
-
-int brute_distinct(vector<int>& arr, int l, int r) {
-    set<int> s(arr.begin() + l, arr.begin() + r + 1);
-    return (int)s.size();
-}
 
 int run_tests() {
     // --- Small test: [1, 2, 3, 2, 1, 4, 3] ---


### PR DESCRIPTION
## Summary

Chains onto PR4c.

- Extract `moDistinctQueries()` from `main()`; fully self-contained function
- `#include <bits/stdc++.h>`, `using namespace std`
- Expand `add`/`rem` lambdas to multi-line
- Extract Mo sort comparator into named lambda `moCmp` with comment explaining the alternating-direction trick

**`test_mo_algo.cpp`**: `brute_distinct` helper (set-based) verifies every assertion; two stress tests (n=500/q=200 small-value domain; n=300/q=300 large-value domain) use chrono seeds printed on failure.

## Test plan

- [ ] `make -C tests run` — 7 tests pass (6 from prior PRs + 1 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_