### PR TITLE
pr8e: refactor MST algorithms and add tests

### DIFF
--- a/Graph Algorithms/MST/Kruskals.cpp
+++ b/Graph Algorithms/MST/Kruskals.cpp
@@ -1,139 +1,49 @@
-// Priyansh Agarwal
-// Check out my Youtube Channel: https://www.youtube.com/c/PriyanshAgarwal
-
-#include<bits/stdc++.h>
-// #include<ext/pb_ds/assoc_container.hpp>
-// #include<ext/pb_ds/tree_policy.hpp>
-
+// O(E log E) — Minimum Spanning Tree via Kruskal's algorithm
+// edges: list of {weight, u, v} (0-indexed nodes)
+// Returns {total MST weight, list of {u, v} MST edges}; weight = -1 if disconnected
+#include <bits/stdc++.h>
 using namespace std;
-using namespace chrono;
-// using namespace __gnu_pbds;
 
-#define fastio() ios_base::sync_with_stdio(false);cin.tie(NULL);cout.tie(NULL)
-#define MOD 1000000007
-#define MOD1 998244353
-#define INF 1e18
-#define nline "\n"
-#define pb push_back
-#define ppb pop_back
-#define mp make_pair
-#define ff first
-#define ss second
-#define PI 3.141592653589793238462
-#define set_bits __builtin_popcountll
-#define sz(x) ((int)(x).size())
-#define all(x) (x).begin(), (x).end()
-
-mt19937 rng(chrono::steady_clock::now().time_since_epoch().count());
-
-#ifdef Priyansh31dec
-#define debug(x) cerr << #x <<" "; _print(x); cerr << endl;
-#else
-#define debug(x);
-#endif
-
-typedef long long ll;
-typedef unsigned long long ull;
-typedef long double lld;
-// typedef tree<pair<ll, ll>, null_type, less<pair<ll, ll>>, rb_tree_tag, tree_order_statistics_node_update > pbds; // find_by_order, order_of_key
-
-void _print(ll t) {cerr << t;}
-void _print(int t) {cerr << t;}
-void _print(string t) {cerr << t;}
-void _print(char t) {cerr << t;}
-void _print(lld t) {cerr << t;}
-void _print(double t) {cerr << t;}
-void _print(ull t) {cerr << t;}
-
-template <class T, class V> void _print(pair <T, V> p);
-template <class T> void _print(vector <T> v);
-template <class T> void _print(set <T> v);
-template <class T, class V> void _print(map <T, V> v);
-template <class T> void _print(multiset <T> v);
-template <class T, class V> void _print(pair <T, V> p) {cerr << "{"; _print(p.ff); cerr << ","; _print(p.ss); cerr << "}";}
-template <class T> void _print(vector <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T> void _print(set <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T> void _print(multiset <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T, class V> void _print(map <T, V> v) {cerr << "[ "; for (auto i : v) {_print(i); cerr << " ";} cerr << "]";}
-// void _print(pbds v) {cerr << "[ "; for (auto i : v) {_print(i); cerr << " ";} cerr << "]";}
-
-/*---------------------------------------------------------------------------------------------------------------------------*/
-ll gcd(ll a, ll b) {if (b > a) {return gcd(b, a);} if (b == 0) {return a;} return gcd(b, a % b);}
-ll expo(ll a, ll b, ll mod) {ll res = 1; while (b > 0) {if (b & 1)res = (res * a) % mod; a = (a * a) % mod; b = b >> 1;} return res;}
-void extendgcd(ll a, ll b, ll*v) {if (b == 0) {v[0] = 1; v[1] = 0; v[2] = a; return ;} extendgcd(b, a % b, v); ll x = v[1]; v[1] = v[0] - v[1] * (a / b); v[0] = x; return;} //pass an arry of size1 3
-ll mminv(ll a, ll b) {ll arr[3]; extendgcd(a, b, arr); return arr[0];} //for non prime b
-ll mminvprime(ll a, ll b) {return expo(a, b - 2, b);}
-bool revsort(ll a, ll b) {return a > b;}
-void swap(int &x, int &y) {int temp = x; x = y; y = temp;}
-ll combination(ll n, ll r, ll m, ll *fact, ll *ifact) {ll val1 = fact[n]; ll val2 = ifact[n - r]; ll val3 = ifact[r]; return (((val1 * val2) % m) * val3) % m;}
-void google(int t) {cout << "Case #" << t << ": ";}
-vector<ll> sieve(int n) {int*arr = new int[n + 1](); vector<ll> vect; for (ll i = 2; i <= n; i++)if (arr[i] == 0) {vect.push_back(i); for (ll j = 2 * i; j <= n; j += i)arr[j] = 1;} return vect;}
-ll mod_add(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a + b) % m) + m) % m;}
-ll mod_mul(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a * b) % m) + m) % m;}
-ll mod_sub(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a - b) % m) + m) % m;}
-ll mod_div(ll a, ll b, ll m) {a = a % m; b = b % m; return (mod_mul(a, mminvprime(b, m), m) + m) % m;}  //only for prime m
-ll phin(ll n) {ll number = n; if (n % 2 == 0) {number /= 2; while (n % 2 == 0) n /= 2;} for (ll i = 3; i <= sqrt(n); i += 2) {if (n % i == 0) {while (n % i == 0)n /= i; number = (number / i * (i - 1));}} if (n > 1)number = (number / n * (n - 1)) ; return number;} //O(sqrt(N))
-void precision(int a) {cout << setprecision(a) << fixed;}
-/*--------------------------------------------------------------------------------------------------------------------------*/
-
-int get(int a, vector<int>& component) {
-	return component[a] = (component[a] == a ? a : get(component[a], component));
-}
-void merge(int a, int b, vector<int>& rank, vector<int>& component) {
-	a = get(a, component);
-	b = get(b, component);
-	if (a == b)
-		return;
-	if (rank[a] == rank[b])
-		rank[a]++;
-	if (rank[a] > rank[b])
-		component[b] = a;
-	else
-		component[a] = b;
+int kruskalGet(int a, vector<int>& parent) {
+    return parent[a] = (parent[a] == a ? a : kruskalGet(parent[a], parent));
 }
 
-void solve() {
-
-	int n, m;
-	cin >> n >> m;
-	vector<int> component(n);
-	for (int i = 0; i < n; i++) {
-		component[i] = i;
-	}
-	vector<int> rank(n, 0);
-	vector<pair<ll, pair<int, int>>> edges;
-	for (int i = 0; i < m; i++) {
-		int a, b, c;
-		cin >> a >> b >> c;
-		edges.push_back({c, {a, b}});
-	}
-	sort(edges.begin(), edges.end());
-	vector<pair<pair<int, int>, ll>> ans;
-	for (auto i : edges) {
-		if (sz(ans) == n - 1)
-			break;
-		int a = i.ss.ff;
-		int b = i.ss.ss;
-		if (get(a, component) != get(b, component)) {
-			merge(a, b, rank, component);
-			ans.push_back({{min(a, b), max(b, a)}, i.ff});
-		}
-	}
-	for (auto i : ans) {
-		cout << i.ff.ff << " " << i.ff.ss << " " << i.ss << endl;
-	}
+void kruskalMerge(int a, int b, vector<int>& rank, vector<int>& parent) {
+    a = kruskalGet(a, parent);
+    b = kruskalGet(b, parent);
+    if (a == b) {
+        return;
+    }
+    if (rank[a] == rank[b]) {
+        rank[a]++;
+    }
+    if (rank[a] > rank[b]) {
+        parent[b] = a;
+    } else {
+        parent[a] = b;
+    }
 }
 
-int main() {
-#ifdef Priyansh31dec
-	freopen("Error.txt", "w", stderr);
-#endif
-	fastio();
-	auto start1 = high_resolution_clock::now();
-	solve();
-	auto stop1 = high_resolution_clock::now();
-	auto duration = duration_cast<microseconds>(stop1 - start1);
-#ifdef Priyansh31dec
-	cerr << "Time: " << duration . count() / 1000 << endl;
-#endif
+pair<long long, vector<pair<int, int>>> kruskal(int n, vector<tuple<long long, int, int>> edges) {
+    sort(edges.begin(), edges.end());
+    vector<int> parent(n), rank(n, 0);
+    for (int i = 0; i < n; i++) {
+        parent[i] = i;
+    }
+    long long totalWeight = 0;
+    vector<pair<int, int>> mstEdges;
+    for (auto [w, u, v] : edges) {
+        if ((int)mstEdges.size() == n - 1) {
+            break;
+        }
+        if (kruskalGet(u, parent) != kruskalGet(v, parent)) {
+            kruskalMerge(u, v, rank, parent);
+            totalWeight += w;
+            mstEdges.push_back({u, v});
+        }
+    }
+    if ((int)mstEdges.size() < n - 1) {
+        return {-1, {}};
+    }
+    return {totalWeight, mstEdges};
 }

--- a/Graph Algorithms/MST/Prims.cpp
+++ b/Graph Algorithms/MST/Prims.cpp
@@ -1,131 +1,41 @@
-// Priyansh Agarwal
-// Check out my Youtube Channel: https://www.youtube.com/c/PriyanshAgarwal
-
-#include<bits/stdc++.h>
-// #include<ext/pb_ds/assoc_container.hpp>
-// #include<ext/pb_ds/tree_policy.hpp>
-
+// O((V + E) log V) — Minimum Spanning Tree via Prim's algorithm
+// adj[u] = list of {v, weight} (0-indexed nodes, undirected graph)
+// Returns {total MST weight, list of {u, v} MST edges}; weight = -1 if disconnected
+#include <bits/stdc++.h>
 using namespace std;
-using namespace chrono;
-// using namespace __gnu_pbds;
 
-#define fastio() ios_base::sync_with_stdio(false);cin.tie(NULL);cout.tie(NULL)
-#define MOD 1000000007
-#define MOD1 998244353
-#define INF 1e18
-#define nline "\n"
-#define pb push_back
-#define ppb pop_back
-#define mp make_pair
-#define ff first
-#define ss second
-#define PI 3.141592653589793238462
-#define set_bits __builtin_popcountll
-#define sz(x) ((int)(x).size())
-#define all(x) (x).begin(), (x).end()
+const long long INF = 2e18;
 
-mt19937 rng(chrono::steady_clock::now().time_since_epoch().count());
-
-#ifdef Priyansh31dec
-#define debug(x) cerr << #x <<" "; _print(x); cerr << endl;
-#else
-#define debug(x);
-#endif
-
-typedef long long ll;
-typedef unsigned long long ull;
-typedef long double lld;
-// typedef tree<pair<ll, ll>, null_type, less<pair<ll, ll>>, rb_tree_tag, tree_order_statistics_node_update > pbds; // find_by_order, order_of_key
-
-void _print(ll t) {cerr << t;}
-void _print(int t) {cerr << t;}
-void _print(string t) {cerr << t;}
-void _print(char t) {cerr << t;}
-void _print(lld t) {cerr << t;}
-void _print(double t) {cerr << t;}
-void _print(ull t) {cerr << t;}
-
-template <class T, class V> void _print(pair <T, V> p);
-template <class T> void _print(vector <T> v);
-template <class T> void _print(set <T> v);
-template <class T, class V> void _print(map <T, V> v);
-template <class T> void _print(multiset <T> v);
-template <class T, class V> void _print(pair <T, V> p) {cerr << "{"; _print(p.ff); cerr << ","; _print(p.ss); cerr << "}";}
-template <class T> void _print(vector <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T> void _print(set <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T> void _print(multiset <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T, class V> void _print(map <T, V> v) {cerr << "[ "; for (auto i : v) {_print(i); cerr << " ";} cerr << "]";}
-// void _print(pbds v) {cerr << "[ "; for (auto i : v) {_print(i); cerr << " ";} cerr << "]";}
-
-/*---------------------------------------------------------------------------------------------------------------------------*/
-ll gcd(ll a, ll b) {if (b > a) {return gcd(b, a);} if (b == 0) {return a;} return gcd(b, a % b);}
-ll expo(ll a, ll b, ll mod) {ll res = 1; while (b > 0) {if (b & 1)res = (res * a) % mod; a = (a * a) % mod; b = b >> 1;} return res;}
-void extendgcd(ll a, ll b, ll*v) {if (b == 0) {v[0] = 1; v[1] = 0; v[2] = a; return ;} extendgcd(b, a % b, v); ll x = v[1]; v[1] = v[0] - v[1] * (a / b); v[0] = x; return;} //pass an arry of size1 3
-ll mminv(ll a, ll b) {ll arr[3]; extendgcd(a, b, arr); return arr[0];} //for non prime b
-ll mminvprime(ll a, ll b) {return expo(a, b - 2, b);}
-bool revsort(ll a, ll b) {return a > b;}
-void swap(int &x, int &y) {int temp = x; x = y; y = temp;}
-ll combination(ll n, ll r, ll m, ll *fact, ll *ifact) {ll val1 = fact[n]; ll val2 = ifact[n - r]; ll val3 = ifact[r]; return (((val1 * val2) % m) * val3) % m;}
-void google(int t) {cout << "Case #" << t << ": ";}
-vector<ll> sieve(int n) {int*arr = new int[n + 1](); vector<ll> vect; for (ll i = 2; i <= n; i++)if (arr[i] == 0) {vect.push_back(i); for (ll j = 2 * i; j <= n; j += i)arr[j] = 1;} return vect;}
-ll mod_add(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a + b) % m) + m) % m;}
-ll mod_mul(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a * b) % m) + m) % m;}
-ll mod_sub(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a - b) % m) + m) % m;}
-ll mod_div(ll a, ll b, ll m) {a = a % m; b = b % m; return (mod_mul(a, mminvprime(b, m), m) + m) % m;}  //only for prime m
-ll phin(ll n) {ll number = n; if (n % 2 == 0) {number /= 2; while (n % 2 == 0) n /= 2;} for (ll i = 3; i <= sqrt(n); i += 2) {if (n % i == 0) {while (n % i == 0)n /= i; number = (number / i * (i - 1));}} if (n > 1)number = (number / n * (n - 1)) ; return number;} //O(sqrt(N))
-void precision(int a) {cout << setprecision(a) << fixed;}
-/*--------------------------------------------------------------------------------------------------------------------------*/
-
-
-void solve() {
-	int n, m;
-	cin >> n >> m;
-	vector<pair<int, ll>> *edges = new vector<pair<int, ll>>[n];
-	for (int i = 0; i < m; i++) {
-		int a, b, c;
-		cin >> a >> b >> c;
-		edges[a].pb({b, c});
-		edges[b].pb({a, c});
-	}
-	set<pair<ll, int>> pq;
-	vector<ll> dist(n, INF);
-	dist[0] = 0;
-	vector<bool> visited(n);
-	vector<int> parent(n, -1);
-	pq.insert({0, 0});
-	for (int i = 0; i < n; i++) {
-		pair<ll, int> top = *pq.begin();
-		pq.erase(top);
-		int best = top.ss;
-		visited[best] = true;
-		for (auto i : edges[best]) {
-			if ((!visited[i.ff]) && dist[i.ff] > i.ss) {
-				pq.erase({dist[i.ff], i.ff});
-				dist[i.ff] = i.ss;
-				pq.insert({dist[i.ff], i.ff});
-				parent[i.ff] = best;
-			}
-		}
-	}
-	for (int i = 1; i < n; i++) {
-		if (parent[i] < i) {
-			cout << parent[i] << " " << i << " " << dist[i] << nline;
-		} else {
-			cout << i << " " << parent[i] << " " << dist[i] << nline;
-		}
-	}
-}
-
-int main() {
-#ifdef Priyansh31dec
-	freopen("Error.txt", "w", stderr);
-#endif
-	fastio();
-	auto start1 = high_resolution_clock::now();
-	solve();
-	auto stop1 = high_resolution_clock::now();
-	auto duration = duration_cast<microseconds>(stop1 - start1);
-#ifdef Priyansh31dec
-	cerr << "Time: " << duration . count() / 1000 << endl;
-#endif
+pair<long long, vector<pair<int, int>>> prims(int n, vector<pair<int, long long>>* adj) {
+    vector<long long> dist(n, INF);
+    vector<bool> visited(n, false);
+    vector<int> parent(n, -1);
+    set<pair<long long, int>> pq;
+    dist[0] = 0;
+    pq.insert({0, 0});
+    long long totalWeight = 0;
+    int count = 0;
+    while (!pq.empty()) {
+        auto [d, u] = *pq.begin();
+        pq.erase(pq.begin());
+        visited[u] = true;
+        totalWeight += d;
+        count++;
+        for (auto [v, w] : adj[u]) {
+            if (!visited[v] && w < dist[v]) {
+                pq.erase({dist[v], v});
+                dist[v] = w;
+                parent[v] = u;
+                pq.insert({dist[v], v});
+            }
+        }
+    }
+    if (count < n) {
+        return {-1, {}};
+    }
+    vector<pair<int, int>> mstEdges;
+    for (int i = 1; i < n; i++) {
+        mstEdges.push_back({parent[i], i});
+    }
+    return {totalWeight, mstEdges};
 }

--- a/tests/graph/mst/test_kruskals.cpp
+++ b/tests/graph/mst/test_kruskals.cpp
@@ -1,0 +1,89 @@
+#include "common.h"
+#include "graph_utils.h"
+#include "Graph Algorithms/MST/Kruskals.cpp"
+
+using namespace std;
+
+// Build edge list from undirected WAdj (each undirected edge stored once)
+vector<tuple<long long, int, int>> make_edges(const WAdj& g, int n) {
+    vector<tuple<long long, int, int>> edges;
+    for (int u = 0; u < n; u++) {
+        for (auto [v, w] : g[u]) {
+            if (u < v) edges.push_back({w, u, v});
+        }
+    }
+    return edges;
+}
+
+int run_tests() {
+    // --- Small known graph ---
+    // 0 -1- 1 -2- 2 -3- 3
+    //  \___________5___/
+    //       \___10___/
+    {
+        int n = 4;
+        vector<tuple<long long, int, int>> edges = {
+            {1, 0, 1}, {2, 1, 2}, {3, 2, 3}, {5, 0, 2}, {10, 0, 3}
+        };
+        auto [w, mst] = kruskal(n, edges);
+        ASSERT_EQ(w, 6); // 1 + 2 + 3
+        ASSERT_TRUE(is_spanning_tree(n, mst));
+    }
+
+    // --- Single node ---
+    {
+        int n = 1;
+        vector<tuple<long long, int, int>> edges;
+        auto [w, mst] = kruskal(n, edges);
+        ASSERT_EQ(w, 0);
+        ASSERT_EQ((int)mst.size(), 0);
+    }
+
+    // --- Two nodes, single edge ---
+    {
+        int n = 2;
+        vector<tuple<long long, int, int>> edges = {{7, 0, 1}};
+        auto [w, mst] = kruskal(n, edges);
+        ASSERT_EQ(w, 7);
+        ASSERT_TRUE(is_spanning_tree(n, mst));
+    }
+
+    // --- Disconnected graph returns -1 ---
+    {
+        int n = 4;
+        vector<tuple<long long, int, int>> edges = {
+            {1, 0, 1}, {2, 2, 3}
+        };
+        auto [w, mst] = kruskal(n, edges);
+        ASSERT_EQ(w, -1);
+        ASSERT_TRUE(mst.empty());
+    }
+
+    // --- Parallel edges: picks the lighter one ---
+    {
+        int n = 2;
+        vector<tuple<long long, int, int>> edges = {{5, 0, 1}, {3, 0, 1}};
+        auto [w, mst] = kruskal(n, edges);
+        ASSERT_EQ(w, 3);
+    }
+
+    // --- Stress test: weight matches brute_mst_weight on random graphs ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        for (int t = 0; t < 30; t++) {
+            int n = 5 + rng() % 20;
+            WAdj g = gen_connected_weighted(n, n / 2, 100, rng);
+            auto edges = make_edges(g, n);
+            auto [w, mst] = kruskal(n, edges);
+            long long expected = brute_mst_weight(n, edges);
+            if (w != expected) cerr << "Stress test failed (seed=" << seed << " t=" << t << ")\n";
+            ASSERT_EQ(w, expected);
+            ASSERT_TRUE(is_spanning_tree(n, mst));
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/graph/mst/test_prims.cpp
+++ b/tests/graph/mst/test_prims.cpp
@@ -1,0 +1,112 @@
+#include "common.h"
+#include "graph_utils.h"
+#include "Graph Algorithms/MST/Prims.cpp"
+
+using namespace std;
+
+vector<pair<int, long long>>* make_adj(const WAdj& g, int n) {
+    auto* adj = new vector<pair<int, long long>>[n];
+    for (int u = 0; u < n; u++) {
+        adj[u] = g[u];
+    }
+    return adj;
+}
+
+// Build edge list from undirected WAdj for brute_mst_weight reference
+vector<tuple<long long, int, int>> make_edges(const WAdj& g, int n) {
+    vector<tuple<long long, int, int>> edges;
+    for (int u = 0; u < n; u++) {
+        for (auto [v, w] : g[u]) {
+            if (u < v) edges.push_back({w, u, v});
+        }
+    }
+    return edges;
+}
+
+int run_tests() {
+    // --- Small known graph (same as Kruskal test) ---
+    {
+        int n = 4;
+        WAdj g(n);
+        g[0].push_back({1, 1}); g[1].push_back({0, 1});
+        g[1].push_back({2, 2}); g[2].push_back({1, 2});
+        g[2].push_back({3, 3}); g[3].push_back({2, 3});
+        g[0].push_back({2, 5}); g[2].push_back({0, 5});
+        g[0].push_back({3, 10}); g[3].push_back({0, 10});
+        auto* adj = make_adj(g, n);
+        auto [w, mst] = prims(n, adj);
+        ASSERT_EQ(w, 6); // 1 + 2 + 3
+        ASSERT_TRUE(is_spanning_tree(n, mst));
+        delete[] adj;
+    }
+
+    // --- Single node ---
+    {
+        int n = 1;
+        WAdj g(n);
+        auto* adj = make_adj(g, n);
+        auto [w, mst] = prims(n, adj);
+        ASSERT_EQ(w, 0);
+        ASSERT_EQ((int)mst.size(), 0);
+        delete[] adj;
+    }
+
+    // --- Two nodes, single edge ---
+    {
+        int n = 2;
+        WAdj g(n);
+        g[0].push_back({1, 7}); g[1].push_back({0, 7});
+        auto* adj = make_adj(g, n);
+        auto [w, mst] = prims(n, adj);
+        ASSERT_EQ(w, 7);
+        ASSERT_TRUE(is_spanning_tree(n, mst));
+        delete[] adj;
+    }
+
+    // --- Disconnected graph returns -1 ---
+    {
+        int n = 4;
+        WAdj g(n);
+        g[0].push_back({1, 1}); g[1].push_back({0, 1});
+        // nodes 2 and 3 isolated
+        auto* adj = make_adj(g, n);
+        auto [w, mst] = prims(n, adj);
+        ASSERT_EQ(w, -1);
+        ASSERT_TRUE(mst.empty());
+        delete[] adj;
+    }
+
+    // --- Parallel edges: MST picks the lighter one ---
+    {
+        int n = 2;
+        WAdj g(n);
+        g[0].push_back({1, 5}); g[1].push_back({0, 5});
+        g[0].push_back({1, 3}); g[1].push_back({0, 3});
+        auto* adj = make_adj(g, n);
+        auto [w, mst] = prims(n, adj);
+        ASSERT_EQ(w, 3);
+        delete[] adj;
+    }
+
+    // --- Stress test: weight matches brute_mst_weight, MST is a spanning tree ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        for (int t = 0; t < 30; t++) {
+            int n = 5 + rng() % 20;
+            WAdj g = gen_connected_weighted(n, n / 2, 100, rng);
+            auto* adj = make_adj(g, n);
+            auto [w, mst] = prims(n, adj);
+            auto edges = make_edges(g, n);
+            long long expected = brute_mst_weight(n, edges);
+            if (w != expected) cerr << "Stress test failed (seed=" << seed << " t=" << t << ")\n";
+            ASSERT_EQ(w, expected);
+            ASSERT_TRUE(is_spanning_tree(n, mst));
+            delete[] adj;
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }


### PR DESCRIPTION
## Summary

- Strips full boilerplate from `Kruskals.cpp` — extracts `kruskalGet`, `kruskalMerge`, `kruskal()` as standalone functions; returns `{totalWeight, mstEdges}` or `{-1, {}}` if disconnected
- Rewrites `Prims.cpp` (replacing PrimsUpdated boilerplate) — clean `prims()` using `set`-based priority queue; same return signature as Kruskal for consistency
- Adds `tests/graph/mst/test_kruskals.cpp` and `tests/graph/mst/test_prims.cpp`

## Test plan

- [ ] Known 4-node graph: weight = 6 (edges 1+2+3)
- [ ] Single node: weight = 0, empty edge list
- [ ] Two nodes, single edge
- [ ] Disconnected graph returns weight = -1
- [ ] Parallel edges: picks lighter one
- [ ] `is_spanning_tree` check on returned edge list
- [ ] 30-iteration stress test: weight matches `brute_mst_weight` on random connected graphs

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_