### PR TITLE
pr8f: refactor network flow algorithms and add tests

### DIFF
--- a/Graph Algorithms/Network Flow/EdmondsKarp.cpp
+++ b/Graph Algorithms/Network Flow/EdmondsKarp.cpp
@@ -1,87 +1,90 @@
-struct Edge{
+// O(V * E²) — Maximum flow via Edmonds-Karp (BFS augmenting paths)
+// Usage: Flow f(adj, n, src, sink); long long result = f.maxFlow();
+// adj[u] = list of {v, capacity} (directed edges)
+#include <bits/stdc++.h>
+using namespace std;
+
+const long long INF = 2e18;
+
+struct Edge {
     int index;
     int src, dest;
-    ll val;
+    long long val;
     int residualIndex;
 };
-struct Flow{
+
+struct Flow {
     int n;
     int src, dest;
-    int iteration = 0;
+    int iteration;
     vector<Edge> edgesT;
     vector<vector<int>> edges;
     vector<int> visited;
     bool solved;
-    ll flow;
-    Flow(vector<pair<int, ll>>* edges1, int n1, int s, int d){
-        n = n1, src = s, dest = d;
+    long long flow;
+
+    Flow(vector<pair<int, long long>>* adj, int n, int src, int dest) {
+        this->n = n;
+        this->src = src;
+        this->dest = dest;
         solved = false;
-        flow = 0, iteration = 1;
-        visited.resize(n);
-        fill(all(visited), 0);
+        flow = 0;
+        iteration = 1;
+        visited.resize(n, 0);
         edges.resize(n);
-        for(int i = 0; i < n; i++){
-            for(auto j : edges1[i]){
-                Edge e1 = {sz(edgesT), i, j.ff, j.ss, sz(edgesT) + 1};
-                Edge e2 = {sz(edgesT) + 1, j.ff, i, 0, sz(edgesT)};
-                edgesT.pb(e1);
-                edgesT.pb(e2);
-                edges[i].pb(e1.index);
-                edges[j.ff].pb(e2.index);
+        for (int i = 0; i < n; i++) {
+            for (auto [v, cap] : adj[i]) {
+                int idx = (int)edgesT.size();
+                Edge e1 = {idx, i, v, cap, idx + 1};
+                Edge e2 = {idx + 1, v, i, 0, idx};
+                edgesT.push_back(e1);
+                edgesT.push_back(e2);
+                edges[i].push_back(e1.index);
+                edges[v].push_back(e2.index);
             }
         }
     }
-    ll bfs(int root){
+
+    long long bfs(int root) {
         queue<int> qu;
         qu.push(root);
         visited[root] = iteration;
         vector<int> prev(n, -1);
-        while(!qu.empty()){
+        while (!qu.empty()) {
             int node = qu.front();
             qu.pop();
-            if(node == dest)
-                break;
-            for(auto i : edges[node]){
-                Edge e1 = edgesT[i];
-                if(visited[e1.dest] != iteration && e1.val > 0){
+            if (node == dest) break;
+            for (int i : edges[node]) {
+                Edge& e1 = edgesT[i];
+                if (visited[e1.dest] != iteration && e1.val > 0) {
                     visited[e1.dest] = iteration;
                     prev[e1.dest] = e1.index;
-                    qu.push(e1.dest); 
+                    qu.push(e1.dest);
                 }
             }
         }
-        int currNode = dest;
-        if(prev[currNode] == -1)
-            return 0;
-        ll finalValue = INF;
-        while(prev[currNode] != -1){
-            Edge e1 = edgesT[prev[currNode]];
-            finalValue = min(finalValue, e1.val);
-            currNode = e1.src;
+        if (prev[dest] == -1) return 0;
+        long long finalValue = INF;
+        for (int cur = dest; prev[cur] != -1; cur = edgesT[prev[cur]].src) {
+            finalValue = min(finalValue, edgesT[prev[cur]].val);
         }
-        currNode = dest;
-        while(prev[currNode] != -1){
-            Edge e1 = edgesT[prev[currNode]];
-            e1.val -= finalValue;
-            edgesT[e1.index] = e1;
+        for (int cur = dest; prev[cur] != -1; cur = edgesT[prev[cur]].src) {
+            Edge& e1 = edgesT[prev[cur]];
             edgesT[e1.residualIndex].val += finalValue;
-            currNode = e1.src;
+            e1.val -= finalValue;
         }
         return finalValue;
     }
-    void EdmondsKarp(){
-        while(true){
-            ll f = bfs(src);
-            if(f == 0)
-                return;
-            flow += f;
-            iteration++;
-        }
-    }
-    ll maxFlow(){
-        if(!solved){
+
+    long long maxFlow() {
+        if (!solved) {
             solved = true;
-            EdmondsKarp();
+            while (true) {
+                long long f = bfs(src);
+                if (f == 0) break;
+                flow += f;
+                iteration++;
+            }
         }
         return flow;
     }

--- a/Graph Algorithms/Network Flow/FordFulkerson.cpp
+++ b/Graph Algorithms/Network Flow/FordFulkerson.cpp
@@ -1,71 +1,78 @@
-struct Edge{
+// O(E * maxFlow) — Maximum flow via Ford-Fulkerson (DFS augmenting paths)
+// Usage: Flow f(adj, n, src, sink); long long result = f.maxFlow();
+// adj[u] = list of {v, capacity} (directed edges)
+#include <bits/stdc++.h>
+using namespace std;
+
+const long long INF = 2e18;
+
+struct Edge {
     int index;
     int src, dest;
-    ll val;
+    long long val;
     int residualIndex;
 };
-struct Flow{
+
+struct Flow {
     int n;
     int src, dest;
-    int iteration = 0;
+    int iteration;
     vector<Edge> edgesT;
     vector<vector<int>> edges;
     vector<int> visited;
     bool solved;
-    ll flow;
-    Flow(vector<pair<int, ll>>* edges1, int n1, int s, int d){
-        n = n1, src = s, dest = d;
+    long long flow;
+
+    Flow(vector<pair<int, long long>>* adj, int n, int src, int dest) {
+        this->n = n;
+        this->src = src;
+        this->dest = dest;
         solved = false;
-        flow = 0, iteration = 1;
-        visited.resize(n);
-        fill(all(visited), 0);
+        flow = 0;
+        iteration = 1;
+        visited.resize(n, 0);
         edges.resize(n);
-        for(int i = 0; i < n; i++){
-            for(auto j : edges1[i]){
-                Edge e1 = {sz(edgesT), i, j.ff, j.ss, sz(edgesT) + 1};
-                Edge e2 = {sz(edgesT) + 1, j.ff, i, 0, sz(edgesT)};
-                edgesT.pb(e1);
-                edgesT.pb(e2);
-                edges[i].pb(e1.index);
-                edges[j.ff].pb(e2.index);
+        for (int i = 0; i < n; i++) {
+            for (auto [v, cap] : adj[i]) {
+                int idx = (int)edgesT.size();
+                Edge e1 = {idx, i, v, cap, idx + 1};
+                Edge e2 = {idx + 1, v, i, 0, idx};
+                edgesT.push_back(e1);
+                edgesT.push_back(e2);
+                edges[i].push_back(e1.index);
+                edges[v].push_back(e2.index);
             }
         }
     }
-    ll dfs(int root, ll currValue){
+
+    long long dfs(int root, long long currValue) {
         visited[root] = iteration;
-        if(root == dest){
+        if (root == dest) {
             return currValue;
         }
-        for(auto i : edges[root]){
-            Edge e1 = edgesT[i];
-            Edge e2 = edgesT[e1.residualIndex];
-            if(visited[e1.dest] != iteration && e1.val > 0){
-                ll val = dfs(e1.dest, min(e1.val, currValue));
-                if(val > 0){
+        for (int i : edges[root]) {
+            Edge& e1 = edgesT[i];
+            if (visited[e1.dest] != iteration && e1.val > 0) {
+                long long val = dfs(e1.dest, min(e1.val, currValue));
+                if (val > 0) {
+                    edgesT[e1.residualIndex].val += val;
                     e1.val -= val;
-                    e2.val += val;
-                    edgesT[i] = e1;
-                    edgesT[e1.residualIndex] = e2;
                     return val;
                 }
             }
         }
         return 0;
-         
     }
-    void FordFulkersonFlow(){
-        while(true){ // random shuffle before every iteration to tackle specially constructed cases
-            ll f = dfs(src, INF);
-            if(f == 0)
-                return;
-            flow += f;
-            iteration++;
-        }
-    }
-    ll maxFlow(){
-        if(!solved){
+
+    long long maxFlow() {
+        if (!solved) {
             solved = true;
-            FordFulkersonFlow();
+            while (true) {
+                long long f = dfs(src, INF);
+                if (f == 0) break;
+                flow += f;
+                iteration++;
+            }
         }
         return flow;
     }

--- a/tests/graph/network_flow/test_edmonds_karp.cpp
+++ b/tests/graph/network_flow/test_edmonds_karp.cpp
@@ -1,0 +1,111 @@
+#include "common.h"
+#include "graph_utils.h"
+#include "Graph Algorithms/Network Flow/EdmondsKarp.cpp"
+
+using namespace std;
+
+vector<pair<int, long long>>* make_adj(const WAdj& g, int n) {
+    auto* adj = new vector<pair<int, long long>>[n];
+    for (int u = 0; u < n; u++) {
+        adj[u] = g[u];
+    }
+    return adj;
+}
+
+// Build capacity matrix from WAdj for brute_max_flow reference
+vector<vector<long long>> make_cap(const WAdj& g, int n) {
+    vector<vector<long long>> cap(n, vector<long long>(n, 0));
+    for (int u = 0; u < n; u++) {
+        for (auto [v, c] : g[u]) {
+            cap[u][v] += c;
+        }
+    }
+    return cap;
+}
+
+int run_tests() {
+    // --- Small known graph: same as Ford-Fulkerson test ---
+    // 0→1 (10), 0→2 (5), 1→3 (7), 2→3 (8); max flow = 12
+    {
+        int n = 4;
+        WAdj g(n);
+        g[0].push_back({1, 10});
+        g[0].push_back({2, 5});
+        g[1].push_back({3, 7});
+        g[2].push_back({3, 8});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 3);
+        ASSERT_EQ(f.maxFlow(), 12);
+        delete[] adj;
+    }
+
+    // --- No path from src to sink ---
+    {
+        int n = 3;
+        WAdj g(n);
+        g[0].push_back({1, 5}); // no edge to node 2
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 2);
+        ASSERT_EQ(f.maxFlow(), 0);
+        delete[] adj;
+    }
+
+    // --- Single bottleneck edge ---
+    {
+        int n = 4;
+        WAdj g(n);
+        g[0].push_back({1, 100});
+        g[1].push_back({2, 3}); // bottleneck
+        g[2].push_back({3, 100});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 3);
+        ASSERT_EQ(f.maxFlow(), 3);
+        delete[] adj;
+    }
+
+    // --- Two nodes, direct edge ---
+    {
+        int n = 2;
+        WAdj g(n);
+        g[0].push_back({1, 7});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 1);
+        ASSERT_EQ(f.maxFlow(), 7);
+        delete[] adj;
+    }
+
+    // --- maxFlow() is idempotent (calling twice returns same value) ---
+    {
+        int n = 3;
+        WAdj g(n);
+        g[0].push_back({1, 4});
+        g[1].push_back({2, 6});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 2);
+        long long first = f.maxFlow();
+        long long second = f.maxFlow();
+        ASSERT_EQ(first, second);
+        delete[] adj;
+    }
+
+    // --- Stress test: compare against brute_max_flow ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        for (int t = 0; t < 20; t++) {
+            int n = 4 + rng() % 8;
+            WAdj g = gen_flow_network(n, 20, rng);
+            auto* adj = make_adj(g, n);
+            Flow f(adj, n, 0, n - 1);
+            long long got = f.maxFlow();
+            long long expected = brute_max_flow(n, make_cap(g, n), 0, n - 1);
+            if (got != expected) cerr << "Stress test failed (seed=" << seed << " t=" << t << ")\n";
+            ASSERT_EQ(got, expected);
+            delete[] adj;
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }

--- a/tests/graph/network_flow/test_ford_fulkerson.cpp
+++ b/tests/graph/network_flow/test_ford_fulkerson.cpp
@@ -1,0 +1,111 @@
+#include "common.h"
+#include "graph_utils.h"
+#include "Graph Algorithms/Network Flow/FordFulkerson.cpp"
+
+using namespace std;
+
+vector<pair<int, long long>>* make_adj(const WAdj& g, int n) {
+    auto* adj = new vector<pair<int, long long>>[n];
+    for (int u = 0; u < n; u++) {
+        adj[u] = g[u];
+    }
+    return adj;
+}
+
+// Build capacity matrix from WAdj for brute_max_flow reference
+vector<vector<long long>> make_cap(const WAdj& g, int n) {
+    vector<vector<long long>> cap(n, vector<long long>(n, 0));
+    for (int u = 0; u < n; u++) {
+        for (auto [v, c] : g[u]) {
+            cap[u][v] += c;
+        }
+    }
+    return cap;
+}
+
+int run_tests() {
+    // --- Small known graph ---
+    // 0→1 (10), 0→2 (5), 1→3 (7), 2→3 (8); max flow = 12
+    {
+        int n = 4;
+        WAdj g(n);
+        g[0].push_back({1, 10});
+        g[0].push_back({2, 5});
+        g[1].push_back({3, 7});
+        g[2].push_back({3, 8});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 3);
+        ASSERT_EQ(f.maxFlow(), 12);
+        delete[] adj;
+    }
+
+    // --- No path from src to sink ---
+    {
+        int n = 3;
+        WAdj g(n);
+        g[0].push_back({1, 5}); // no edge to node 2
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 2);
+        ASSERT_EQ(f.maxFlow(), 0);
+        delete[] adj;
+    }
+
+    // --- Single bottleneck edge ---
+    {
+        int n = 4;
+        WAdj g(n);
+        g[0].push_back({1, 100});
+        g[1].push_back({2, 3}); // bottleneck
+        g[2].push_back({3, 100});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 3);
+        ASSERT_EQ(f.maxFlow(), 3);
+        delete[] adj;
+    }
+
+    // --- Two nodes, direct edge ---
+    {
+        int n = 2;
+        WAdj g(n);
+        g[0].push_back({1, 7});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 1);
+        ASSERT_EQ(f.maxFlow(), 7);
+        delete[] adj;
+    }
+
+    // --- maxFlow() is idempotent (calling twice returns same value) ---
+    {
+        int n = 3;
+        WAdj g(n);
+        g[0].push_back({1, 4});
+        g[1].push_back({2, 6});
+        auto* adj = make_adj(g, n);
+        Flow f(adj, n, 0, 2);
+        long long first = f.maxFlow();
+        long long second = f.maxFlow();
+        ASSERT_EQ(first, second);
+        delete[] adj;
+    }
+
+    // --- Stress test: compare against brute_max_flow ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        for (int t = 0; t < 20; t++) {
+            int n = 4 + rng() % 8;
+            WAdj g = gen_flow_network(n, 20, rng);
+            auto* adj = make_adj(g, n);
+            Flow f(adj, n, 0, n - 1);
+            long long got = f.maxFlow();
+            long long expected = brute_max_flow(n, make_cap(g, n), 0, n - 1);
+            if (got != expected) cerr << "Stress test failed (seed=" << seed << " t=" << t << ")\n";
+            ASSERT_EQ(got, expected);
+            delete[] adj;
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }


### PR DESCRIPTION
## Summary

- Expands all macros (`ll`, `INF`, `sz`, `pb`, `ff`, `ss`, `all`) in `FordFulkerson.cpp` and `EdmondsKarp.cpp`; adds `#include <bits/stdc++.h>` and `const long long INF`
- Cleans up `Flow` constructor to body-style (`this->n = n`); uses `int idx = edgesT.size()` to avoid repeated `sz()` calls
- Fixes DFS edge update in FordFulkerson to use references (avoids stale-copy pattern)
- Rewrites EdmondsKarp BFS trace-back as range-for loops with references
- Adds `tests/graph/network_flow/test_ford_fulkerson.cpp` and `test_edmonds_karp.cpp`

## Test plan

- [ ] Known graph: 0→1(10), 0→2(5), 1→3(7), 2→3(8) → max flow = 12
- [ ] No path from src to sink → flow = 0
- [ ] Single bottleneck edge → flow = bottleneck capacity
- [ ] Two nodes, direct edge
- [ ] `maxFlow()` is idempotent (same result on second call)
- [ ] 20-iteration stress test: flow matches `brute_max_flow` on random flow networks

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_