### PR TITLE
pr8g: refactor KosarajuSCC and add tests

### DIFF
--- a/Graph Algorithms/SCC/KosarajuSCC.cpp
+++ b/Graph Algorithms/SCC/KosarajuSCC.cpp
@@ -1,143 +1,45 @@
-// Priyansh Agarwal
-// Check out my Youtube Channel: https://www.youtube.com/c/PriyanshAgarwal
-
-#include<bits/stdc++.h>
-// #include<ext/pb_ds/assoc_container.hpp>
-// #include<ext/pb_ds/tree_policy.hpp>
-
+// O(V + E) — Strongly Connected Components via Kosaraju's algorithm
+// edges: forward adjacency list; edgesT: reversed adjacency list (both raw arrays of size n)
+// Returns list of SCCs; each SCC is a list of 0-indexed node IDs
+#include <bits/stdc++.h>
 using namespace std;
-using namespace chrono;
-// using namespace __gnu_pbds;
 
-#define fastio() ios_base::sync_with_stdio(false);cin.tie(NULL);cout.tie(NULL)
-#define MOD 1000000007
-#define MOD1 998244353
-#define INF 1e18
-#define nline "\n"
-#define pb push_back
-#define ppb pop_back
-#define mp make_pair
-#define ff first
-#define ss second
-#define PI 3.141592653589793238462
-#define set_bits __builtin_popcountll
-#define sz(x) ((int)(x).size())
-#define all(x) (x).begin(), (x).end()
-
-mt19937 rng(chrono::steady_clock::now().time_since_epoch().count());
-
-#ifdef Priyansh31dec
-#define debug(x) cerr << #x <<" "; _print(x); cerr << endl;
-#else
-#define debug(x);
-#endif
-
-typedef long long ll;
-typedef unsigned long long ull;
-typedef long double lld;
-// typedef tree<pair<ll, ll>, null_type, less<pair<ll, ll>>, rb_tree_tag, tree_order_statistics_node_update > pbds; // find_by_order, order_of_key
-
-void _print(ll t) {cerr << t;}
-void _print(int t) {cerr << t;}
-void _print(string t) {cerr << t;}
-void _print(char t) {cerr << t;}
-void _print(lld t) {cerr << t;}
-void _print(double t) {cerr << t;}
-void _print(ull t) {cerr << t;}
-
-template <class T, class V> void _print(pair <T, V> p);
-template <class T> void _print(vector <T> v);
-template <class T> void _print(set <T> v);
-template <class T, class V> void _print(map <T, V> v);
-template <class T> void _print(multiset <T> v);
-template <class T, class V> void _print(pair <T, V> p) {cerr << "{"; _print(p.ff); cerr << ","; _print(p.ss); cerr << "}";}
-template <class T> void _print(vector <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T> void _print(set <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T> void _print(multiset <T> v) {cerr << "[ "; for (T i : v) {_print(i); cerr << " ";} cerr << "]";}
-template <class T, class V> void _print(map <T, V> v) {cerr << "[ "; for (auto i : v) {_print(i); cerr << " ";} cerr << "]";}
-// void _print(pbds v) {cerr << "[ "; for (auto i : v) {_print(i); cerr << " ";} cerr << "]";}
-
-/*---------------------------------------------------------------------------------------------------------------------------*/
-ll gcd(ll a, ll b) {if (b > a) {return gcd(b, a);} if (b == 0) {return a;} return gcd(b, a % b);}
-ll expo(ll a, ll b, ll mod) {ll res = 1; while (b > 0) {if (b & 1)res = (res * a) % mod; a = (a * a) % mod; b = b >> 1;} return res;}
-void extendgcd(ll a, ll b, ll*v) {if (b == 0) {v[0] = 1; v[1] = 0; v[2] = a; return ;} extendgcd(b, a % b, v); ll x = v[1]; v[1] = v[0] - v[1] * (a / b); v[0] = x; return;} //pass an arry of size1 3
-ll mminv(ll a, ll b) {ll arr[3]; extendgcd(a, b, arr); return arr[0];} //for non prime b
-ll mminvprime(ll a, ll b) {return expo(a, b - 2, b);}
-bool revsort(ll a, ll b) {return a > b;}
-void swap(int &x, int &y) {int temp = x; x = y; y = temp;}
-ll combination(ll n, ll r, ll m, ll *fact, ll *ifact) {ll val1 = fact[n]; ll val2 = ifact[n - r]; ll val3 = ifact[r]; return (((val1 * val2) % m) * val3) % m;}
-void google(int t) {cout << "Case #" << t << ": ";}
-vector<ll> sieve(int n) {int*arr = new int[n + 1](); vector<ll> vect; for (ll i = 2; i <= n; i++)if (arr[i] == 0) {vect.push_back(i); for (ll j = 2 * i; j <= n; j += i)arr[j] = 1;} return vect;}
-ll mod_add(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a + b) % m) + m) % m;}
-ll mod_mul(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a * b) % m) + m) % m;}
-ll mod_sub(ll a, ll b, ll m) {a = a % m; b = b % m; return (((a - b) % m) + m) % m;}
-ll mod_div(ll a, ll b, ll m) {a = a % m; b = b % m; return (mod_mul(a, mminvprime(b, m), m) + m) % m;}  //only for prime m
-ll phin(ll n) {ll number = n; if (n % 2 == 0) {number /= 2; while (n % 2 == 0) n /= 2;} for (ll i = 3; i <= sqrt(n); i += 2) {if (n % i == 0) {while (n % i == 0)n /= i; number = (number / i * (i - 1));}} if (n > 1)number = (number / n * (n - 1)) ; return number;} //O(sqrt(N))
-void precision(int a) {cout << setprecision(a) << fixed;}
-/*--------------------------------------------------------------------------------------------------------------------------*/
-
-void topoSort(int start, vector<int> *edges, vector<int>& topo, vector<bool>& visited) {
-	visited[start] = true;
-	for (auto i : edges[start]) {
-		if (!visited[i]) {
-			topoSort(i, edges, topo, visited);
-		}
-	}
-	topo.pb(start);
+void topoSort(int start, vector<int>* edges, vector<int>& topo, vector<bool>& visited) {
+    visited[start] = true;
+    for (int i : edges[start]) {
+        if (!visited[i]) {
+            topoSort(i, edges, topo, visited);
+        }
+    }
+    topo.push_back(start);
 }
+
 void getComponent(int start, vector<int>* edges, vector<int>& currComponent, vector<bool>& visited) {
-	currComponent.pb(start);
-	visited[start] = true;
-	for (auto i : edges[start]) {
-		if (!visited[i]) {
-			getComponent(i, edges, currComponent, visited);
-		}
-	}
-}
-vector<vector<int>> getSCC(int n, vector<int>* edges, vector<int>* edgesT) {
-	vector<bool> visited(n);
-	vector<int> topo;
-	for (int i = 0; i < n; i++) {
-		if (!visited[i]) {
-			topoSort(i, edges, topo, visited);
-		}
-	}
-	fill(visited.begin(), visited.end(), false);
-	vector<vector<int>> SCC;
-	for (int i = topo.size() - 1; i >= 0; i--) {
-		if (!visited[topo[i]]) {
-			vector<int> comp;
-			getComponent(topo[i], edgesT, comp, visited);
-			SCC.pb(comp);
-		}
-	}
-	return SCC;
-}
-void solve() {
-	int n, e;
-	cin >> n >> e;
-	vector<int> *edges = new vector<int>[n];
-	vector<int> *edgesT = new vector<int>[n];
-	for (int i = 0; i < e; i++)
-	{
-		int a, b;
-		cin >> a >> b;
-		edges[a - 1].pb(b - 1);
-		edgesT[b - 1].pb(a - 1);
-	}
-	vector<vector<int>> SCC = getSCC(n, edges, edgesT);
+    currComponent.push_back(start);
+    visited[start] = true;
+    for (int i : edges[start]) {
+        if (!visited[i]) {
+            getComponent(i, edges, currComponent, visited);
+        }
+    }
 }
 
-int main() {
-#ifdef Priyansh31dec
-	freopen("Error.txt", "w", stderr);
-#endif
-	fastio();
-	auto start1 = high_resolution_clock::now();
-	solve();
-	auto stop1 = high_resolution_clock::now();
-	auto duration = duration_cast<microseconds>(stop1 - start1);
-#ifdef Priyansh31dec
-	cerr << "Time: " << duration . count() / 1000 << endl;
-#endif
+vector<vector<int>> getSCC(int n, vector<int>* edges, vector<int>* edgesT) {
+    vector<bool> visited(n, false);
+    vector<int> topo;
+    for (int i = 0; i < n; i++) {
+        if (!visited[i]) {
+            topoSort(i, edges, topo, visited);
+        }
+    }
+    fill(visited.begin(), visited.end(), false);
+    vector<vector<int>> SCC;
+    for (int i = (int)topo.size() - 1; i >= 0; i--) {
+        if (!visited[topo[i]]) {
+            vector<int> comp;
+            getComponent(topo[i], edgesT, comp, visited);
+            SCC.push_back(comp);
+        }
+    }
+    return SCC;
 }

--- a/tests/graph/scc/test_kosaraju_scc.cpp
+++ b/tests/graph/scc/test_kosaraju_scc.cpp
@@ -1,0 +1,118 @@
+#include "common.h"
+#include "graph_utils.h"
+#include "Graph Algorithms/SCC/KosarajuSCC.cpp"
+
+using namespace std;
+
+vector<int>* make_fwd(const Adj& g, int n) {
+    auto* adj = new vector<int>[n];
+    for (int u = 0; u < n; u++) adj[u] = g[u];
+    return adj;
+}
+
+vector<int>* make_rev(const Adj& g, int n) {
+    auto* radj = new vector<int>[n];
+    for (int u = 0; u < n; u++) {
+        for (int v : g[u]) radj[v].push_back(u);
+    }
+    return radj;
+}
+
+int run_tests() {
+    // --- Two SCCs connected by a bridge ---
+    // 0⇆1 → 2⇆3 — two SCCs: {0,1} and {2,3}
+    {
+        int n = 4;
+        Adj g(n);
+        g[0].push_back(1); g[1].push_back(0);  // SCC: {0,1}
+        g[1].push_back(2);                       // bridge
+        g[2].push_back(3); g[3].push_back(2);  // SCC: {2,3}
+        auto* fwd = make_fwd(g, n);
+        auto* rev = make_rev(g, n);
+        auto sccs = getSCC(n, fwd, rev);
+        ASSERT_EQ((int)sccs.size(), 2);
+        ASSERT_TRUE(is_valid_scc(g, n, sccs));
+        ASSERT_EQ(brute_scc_count(g, n), 2);
+        delete[] fwd; delete[] rev;
+    }
+
+    // --- Each node is its own SCC (linear DAG) ---
+    {
+        int n = 4;
+        Adj g(n);
+        g[0].push_back(1); g[1].push_back(2); g[2].push_back(3);
+        auto* fwd = make_fwd(g, n);
+        auto* rev = make_rev(g, n);
+        auto sccs = getSCC(n, fwd, rev);
+        ASSERT_EQ((int)sccs.size(), 4);
+        ASSERT_TRUE(is_valid_scc(g, n, sccs));
+        delete[] fwd; delete[] rev;
+    }
+
+    // --- Entire graph is one SCC (cycle) ---
+    {
+        int n = 4;
+        Adj g(n);
+        g[0].push_back(1); g[1].push_back(2);
+        g[2].push_back(3); g[3].push_back(0);
+        auto* fwd = make_fwd(g, n);
+        auto* rev = make_rev(g, n);
+        auto sccs = getSCC(n, fwd, rev);
+        ASSERT_EQ((int)sccs.size(), 1);
+        ASSERT_TRUE(is_valid_scc(g, n, sccs));
+        delete[] fwd; delete[] rev;
+    }
+
+    // --- Single node ---
+    {
+        int n = 1;
+        Adj g(n);
+        auto* fwd = make_fwd(g, n);
+        auto* rev = make_rev(g, n);
+        auto sccs = getSCC(n, fwd, rev);
+        ASSERT_EQ((int)sccs.size(), 1);
+        ASSERT_TRUE(is_valid_scc(g, n, sccs));
+        delete[] fwd; delete[] rev;
+    }
+
+    // --- Three SCCs: {0,1,2}, {3,4}, {5} ---
+    {
+        int n = 6;
+        Adj g(n);
+        g[0].push_back(1); g[1].push_back(2); g[2].push_back(0); // SCC {0,1,2}
+        g[2].push_back(3);                                          // bridge
+        g[3].push_back(4); g[4].push_back(3);                     // SCC {3,4}
+        g[4].push_back(5);                                          // bridge
+        // node 5 is isolated sink, SCC {5}
+        auto* fwd = make_fwd(g, n);
+        auto* rev = make_rev(g, n);
+        auto sccs = getSCC(n, fwd, rev);
+        ASSERT_EQ((int)sccs.size(), 3);
+        ASSERT_TRUE(is_valid_scc(g, n, sccs));
+        ASSERT_EQ(brute_scc_count(g, n), 3);
+        delete[] fwd; delete[] rev;
+    }
+
+    // --- Stress test: SCC count matches brute, decomposition is valid ---
+    {
+        auto seed = chrono::steady_clock::now().time_since_epoch().count();
+        mt19937 rng(seed);
+        for (int t = 0; t < 30; t++) {
+            int n = 5 + rng() % 15;
+            Adj g = gen_directed(n, n + rng() % (n * 2), rng);
+            auto* fwd = make_fwd(g, n);
+            auto* rev = make_rev(g, n);
+            auto sccs = getSCC(n, fwd, rev);
+            int got = (int)sccs.size();
+            int expected = brute_scc_count(g, n);
+            if (got != expected) cerr << "Stress test failed (seed=" << seed << " t=" << t << ")\n";
+            ASSERT_EQ(got, expected);
+            ASSERT_TRUE(is_valid_scc(g, n, sccs));
+            delete[] fwd; delete[] rev;
+        }
+    }
+
+    TEST_PASS();
+}
+
+int main() { return run_tests(); }


### PR DESCRIPTION
## Summary

- Strips full boilerplate from `KosarajuSCC.cpp` — keeps `topoSort`, `getComponent`, `getSCC` functions with explicit types and `.push_back()` replacing `pb`
- Adds `tests/graph/scc/test_kosaraju_scc.cpp`

## Test plan

- [ ] Two SCCs: 0⇆1 → 2⇆3 → 2 components
- [ ] Linear DAG: each node is its own SCC (4 components)
- [ ] Single cycle 0→1→2→3→0: one SCC
- [ ] Single node
- [ ] Three SCCs: {0,1,2}, {3,4}, {5}
- [ ] 30-iteration stress test: SCC count matches `brute_scc_count`; `is_valid_scc` decomposition check passes

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZCiLN1ePVED473EQXZaw2)_