### PR TITLE
Add Sparse Table for O(1) Range Minimum Queries

### DIFF
--- a/Range Queries/SparseTable_RMQ.cpp
+++ b/Range Queries/SparseTable_RMQ.cpp
@@ -1,0 +1,39 @@
+// Sparse Table — Range Minimum Query (RMQ)
+// Build:  O(n log n) time and space
+// Query:  O(1) per query
+// Usage:  static arrays only (no updates after construction).
+//         Call query(l, r) for the minimum in arr[l..r] inclusive.
+
+#include <vector>
+#include <algorithm>
+
+struct SparseTable {
+    int n, LOG;
+    std::vector<std::vector<long long>> st;
+    std::vector<int> log2_floor;
+
+    SparseTable() {}
+
+    SparseTable(const std::vector<long long>& arr) {
+        n = (int)arr.size();
+        LOG = 1;
+        while ((1 << LOG) <= n) LOG++;
+
+        st.assign(LOG, std::vector<long long>(n));
+        log2_floor.resize(n + 1, 0);
+
+        for (int i = 2; i <= n; i++)
+            log2_floor[i] = log2_floor[i / 2] + 1;
+
+        for (int i = 0; i < n; i++) st[0][i] = arr[i];
+
+        for (int j = 1; j < LOG; j++)
+            for (int i = 0; i + (1 << j) <= n; i++)
+                st[j][i] = std::min(st[j-1][i], st[j-1][i + (1 << (j-1))]);
+    }
+
+    long long query(int l, int r) {
+        int k = log2_floor[r - l + 1];
+        return std::min(st[k][l], st[k][r - (1 << k) + 1]);
+    }
+};

--- a/tests/test_sparsetable_rmq.cpp
+++ b/tests/test_sparsetable_rmq.cpp
@@ -1,0 +1,24 @@
+#include "common.h"
+#include "../Range Queries/SparseTable_RMQ.cpp"
+
+int main() {
+    // Typical case
+    std::vector<long long> arr = {3, 1, 4, 1, 5, 9, 2, 6};
+    SparseTable rmq(arr);
+
+    ASSERT_EQ(rmq.query(0, 7), 1LL);  // full array
+    ASSERT_EQ(rmq.query(2, 6), 1LL);  // subarray spanning the second 1
+    ASSERT_EQ(rmq.query(4, 7), 2LL);  // right half, min is 2
+    ASSERT_EQ(rmq.query(0, 1), 1LL);  // leftmost pair
+
+    // Edge: single element queries
+    ASSERT_EQ(rmq.query(0, 0), 3LL);
+    ASSERT_EQ(rmq.query(5, 5), 9LL);
+
+    // Edge: array of size 1
+    std::vector<long long> single = {42};
+    SparseTable rmq2(single);
+    ASSERT_EQ(rmq2.query(0, 0), 42LL);
+
+    TEST_PASS();
+}


### PR DESCRIPTION
## What this adds
A self-contained Sparse Table implementation for static Range Minimum 
Queries (RMQ) under Range Queries/.

## Complexity
- Build: O(n log n) time and space
- Query: O(1) per query

## Implementation notes
- Uses an integer lookup table for floor(log₂) instead of std::log2 
  to avoid floating-point precision issues on edge cases
- No macros or external template dependencies
- Works with long long arrays

## Tests
Covers two cases as required:
- Typical: multiple range queries on an 8-element array
- Edge: single-element queries, array of size 1

Tested locally with the provided test runner.